### PR TITLE
Add support for mute groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # behringer-mixer
-Python module to get basic information from Behringer digital mixers eg X32/XAir etc.
+Python module to get basic information from Behringer digital mixers eg X32/Wing/XAir etc.
 
 Initial inspiration (and some code) comes from https://github.com/onyx-and-iris/xair-api-python.
 
@@ -19,6 +19,7 @@ It also supports
 - Current USB Filename [get]
 - Firmware version
 - Control of head-amps gain/phantom power
+- Mute groups
 
 If you want a module that allows you to control the full functionality of the mixer, eg configuring effects/eq etc then I would recommend checking out https://github.com/onyx-and-iris/xair-api-python instead. Or if you have a focus on the X-Series, you could also look at https://github.com/matiasbarrios/magical-mixers/.
 
@@ -94,6 +95,7 @@ The following keyword arguments may be passed:
     - `mono`
     - `show`
     - `usb`
+    - `mutegroups`
 
 The create function only creates an instance of the mixer, it does not 'connect' to it.
 You should call the `mixer.start()` function to prepare communication and then call `mixer.validate_connection()` to check that the connection to the mixer worked.

--- a/behringer_mixer/mixers/mixer_type_base.py
+++ b/behringer_mixer/mixers/mixer_type_base.py
@@ -16,6 +16,7 @@ class MixerTypeBase(MixerBase):
     num_matrix: int = 0
     num_scenes: int = 100
     num_head_amp: int = 0
+    num_mute_groups: int = 0
     has_mono: bool = False
     num_mains: int = 1
     info_address: str = "/xinfo"
@@ -81,6 +82,10 @@ class MixerTypeBase(MixerBase):
             "mains": {
                 "number": self.num_mains,
                 "base_address": "main",
+            },
+            "mute_groups": {
+                "number": self.num_mute_groups,
+                "base_address": "mutegroups",
             },
             "has_mono": self.has_mono,
         }

--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -16,6 +16,7 @@ class MixerTypeWING(MixerTypeBase):
     has_mono: bool = False
     num_head_amp: int = 0
     num_mains: int = 4
+    num_mute_groups: int = 8
     info_address: str = "/?"
     subscription_string: str = "/*s"
     subscription_renew_string: str = "/*s"
@@ -382,6 +383,14 @@ class MixerTypeWING(MixerTypeBase):
                 "tag": "usb",
                 "input": "/play/$actfile",
                 "output": "/usb/file",
+            },
+            # Mute Groups
+            {
+                "tag": "mutegroups",
+                "input": "/mgrp/{num_mute_groups}/mute",
+                "output": "/mutegroups/{num_mute_groups}/on",
+                "data_type": "boolean",
+                "data_index": 2,
             },
         ]
 

--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -50,11 +50,17 @@ class MixerTypeWING(MixerTypeBase):
                 "tag": "channels",
                 "input": "/ch/{num_channel}/mute",
                 "output": "/ch/{num_channel}/mix_on",
+                "input_padding": {
+                    "num_channel": 1,
+                },
                 "data_type": "boolean_inverted",
                 "data_index": 2,
             },
             {
                 "tag": "channels",
+                "input_padding": {
+                    "num_channel": 1,
+                },
                 "input": "/ch/{num_channel}/$name",
                 "output": "/ch/{num_channel}/config_name",
             },
@@ -62,6 +68,9 @@ class MixerTypeWING(MixerTypeBase):
                 "tag": "channels",
                 "input": "/ch/{num_channel}/$col",
                 "output": "/ch/{num_channel}/config_color",
+                "input_padding": {
+                    "num_channel": 1,
+                },
                 "data_index": 0,
                 "secondary_output": {
                     "_name": {
@@ -78,6 +87,7 @@ class MixerTypeWING(MixerTypeBase):
                 "data_index": 2,
                 "input_padding": {
                     "num_bus": 1,
+                    "num_channel": 1,
                 },
                 "write_transform": "fader_to_db",
                 "output": "/chsend/{num_channel}/{num_bus}/mix_on",

--- a/behringer_mixer/mixers/mixer_type_x32.py
+++ b/behringer_mixer/mixers/mixer_type_x32.py
@@ -13,6 +13,7 @@ class MixerTypeX32(MixerTypeXSeriesBase):
     num_auxrtn: int = 8
     num_matrix: int = 6
     has_mono: bool = True
+    num_mute_groups: int = 6
     num_head_amp: int = 128
 
     def __init__(self, **kwargs):
@@ -50,6 +51,13 @@ class MixerTypeX32(MixerTypeXSeriesBase):
                         "reverse_function": "color_name_to_index",
                     },
                 },
+            },
+            # Mute Groups
+            {
+                "tag": "mutegroups",
+                "input": "/config/mute/{num_mute_groups}",
+                "output": "/mutegroups/{num_mute_groups}/on",
+                "data_type": "boolean",
             },
         ]
         super().__init__(**kwargs)

--- a/behringer_mixer/mixers/mixer_type_xair.py
+++ b/behringer_mixer/mixers/mixer_type_xair.py
@@ -73,5 +73,12 @@ class MixerTypeXAir(MixerTypeXSeriesBase):
                 },
                 "data_type": "boolean",
             },
+            # Mute Groups
+            {
+                "tag": "mutegroups",
+                "input": "/config/mute/{num_mute_groups}",
+                "output": "/mutegroups/{num_mute_groups}/on",
+                "data_type": "boolean",
+            },
         ]
         super().__init__(**kwargs)

--- a/behringer_mixer/mixers/mixer_type_xr12.py
+++ b/behringer_mixer/mixers/mixer_type_xr12.py
@@ -10,3 +10,4 @@ class MixerTypeXR12(MixerTypeXAir):
     num_dca: int = 4
     num_fx: int = 4
     num_head_amp: int = 4
+    num_mute_groups: int = 4

--- a/behringer_mixer/mixers/mixer_type_xr16.py
+++ b/behringer_mixer/mixers/mixer_type_xr16.py
@@ -10,3 +10,4 @@ class MixerTypeXR16(MixerTypeXAir):
     num_dca: int = 4
     num_fx: int = 4
     num_head_amp: int = 8
+    num_mute_groups: int = 4

--- a/behringer_mixer/mixers/mixer_type_xr18.py
+++ b/behringer_mixer/mixers/mixer_type_xr18.py
@@ -11,3 +11,4 @@ class MixerTypeXR18(MixerTypeXAir):
     num_fx: int = 4
     num_auxrtn: int = 2
     num_head_amp: int = 16
+    num_mute_groups: int = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "behringer_mixer"
-version = "0.4.9"
+version = "0.4.10"
 description = "Module to get basic information from Behringer digital mixers eg X32/XAir etc."
 authors = ["wrodie <warren@rodie.net>"]
 license = "MIT"


### PR DESCRIPTION
Add support for controlling the activation/mute on/off of mute groups
Note: This is not the configuration of which channels are in mute groups.

Bug Fix - Fix Channel padding on Wing - Channels<10 not working for mute.