### PR TITLE
fix DCA data index mapping in MixerTypeWING

### DIFF
--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -281,7 +281,7 @@ class MixerTypeWING(MixerTypeBase):
                 "output": "/dca/{num_dca}/mix_fader",
                 "write_transform": "fader_to_db",
                 "input_padding": {"num_dca": 1},
-                "data_index": 2,
+                "data_index": 1,
                 "secondary_output": {
                     "_db": {
                         "data_index": 0,
@@ -292,7 +292,7 @@ class MixerTypeWING(MixerTypeBase):
                 "tag": "dcas",
                 "input": "/dca/{num_dca}/mute",
                 "output": "/dca/{num_dca}/mix_on",
-                "data_index": 0,
+                "data_index": 2,
                 "data_type": "boolean_inverted",
                 "input_padding": {"num_dca": 1},
             },


### PR DESCRIPTION
Fixes #14

WING DCA fader (/dca/{n}/fdr): use the linear 0..1 value at index 1 (was 2) so /dca/{n}/mix_fader reflects the actual fader position.
WING DCA mute (/dca/{n}/mute): use the mute state at index 2 (was 0) so /dca/{n}/mix_on toggles correctly.
Change aligns with the WING Remote Protocols format and fixes the Home Assistant slider/mute behavior.

I will test changes under real life conditions tomorrow and update accordingly. 