### PR TITLE
Fix WING protocol: correct channel count, reliable info load, and color/name mappings

### DIFF
--- a/behringer_mixer/mixer_base.py
+++ b/behringer_mixer/mixer_base.py
@@ -97,7 +97,9 @@ class MixerBase:
         if addr == "/xinfo":
             self.handle_xinfo(data)
             updates = []
-        if addr == "/*":
+        # WING responds to the info query ("/?") with either "/*" or "/?" depending
+        # on firmware / implementation.
+        if addr in ("/*", "/?"):
             self.handle_winfo(data)
             updates = []
         if self._callback_function:

--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -6,7 +6,7 @@ class MixerTypeWING(MixerTypeBase):
 
     port_number: int = 2223
     mixer_type: str = "WING"
-    num_channel: int = 48
+    num_channel: int = 40
     num_bus: int = 16
     num_dca: int = 16
     num_fx: int = 0
@@ -26,6 +26,7 @@ class MixerTypeWING(MixerTypeBase):
 
     def __init__(self, **kwargs):
         self.extra_addresses_to_load = [
+            # Mixer info (WING answers "/?" with a "/*" or "/?" response)
             {
                 "input": "/?",
                 "output": "/status",
@@ -71,10 +72,9 @@ class MixerTypeWING(MixerTypeBase):
                 "input_padding": {
                     "num_channel": 1,
                 },
-                "data_index": 0,
+                "data_index": 2,
                 "secondary_output": {
                     "_name": {
-                        "data_index": 0,
                         "forward_function": "wing_color_index_to_name",
                         "reverse_function": "wing_color_name_to_index",
                     },
@@ -138,13 +138,12 @@ class MixerTypeWING(MixerTypeBase):
             },
             {
                 "tag": "auxins",
-                "input": "/aux/{num_auxin}/$col",
+                "input": "/aux/{num_auxin}/col",
                 "input_padding": {"num_auxin": 1},
                 "output": "/auxin/{num_auxin}/config_color",
-                "data_index": 0,
+                "data_index": 2,
                 "secondary_output": {
                     "_name": {
-                        "data_index": 0,
                         "forward_function": "wing_color_index_to_name",
                         "reverse_function": "wing_color_name_to_index",
                     },
@@ -155,6 +154,7 @@ class MixerTypeWING(MixerTypeBase):
                 "tag": "busses",
                 "input": "/bus/{num_bus}/fdr",
                 "output": "/bus/{num_bus}/mix_fader",
+                "input_padding": {"num_bus": 1},
                 "data_index": 1,
                 "write_transform": "fader_to_db",
                 "secondary_output": {
@@ -167,6 +167,7 @@ class MixerTypeWING(MixerTypeBase):
                 "tag": "busses",
                 "input": "/bus/{num_bus}/mute",
                 "output": "/bus/{num_bus}/mix_on",
+                "input_padding": {"num_bus": 1},
                 "data_type": "boolean_inverted",
                 "data_index": 2,
             },
@@ -174,15 +175,16 @@ class MixerTypeWING(MixerTypeBase):
                 "tag": "busses",
                 "input": "/bus/{num_bus}/$name",
                 "output": "/bus/{num_bus}/config_name",
+                "input_padding": {"num_bus": 1},
             },
             {
                 "tag": "busses",
                 "input": "/bus/{num_bus}/$col",
                 "output": "/bus/{num_bus}/config_color",
-                "data_index": 0,
+                "input_padding": {"num_bus": 1},
+                "data_index": 2,
                 "secondary_output": {
                     "_name": {
-                        "data_index": 0,
                         "forward_function": "wing_color_index_to_name",
                         "reverse_function": "wing_color_name_to_index",
                     },
@@ -265,10 +267,9 @@ class MixerTypeWING(MixerTypeBase):
                 "input": "/mtx/{num_matrix}/$col",
                 "output": "/mtx/{num_matrix}/config_color",
                 "input_padding": {"num_matrix": 1},
-                "data_index": 0,
+                "data_index": 2,
                 "secondary_output": {
                     "_name": {
-                        "data_index": 0,
                         "forward_function": "wing_color_index_to_name",
                         "reverse_function": "wing_color_name_to_index",
                     },
@@ -307,10 +308,9 @@ class MixerTypeWING(MixerTypeBase):
                 "input": "/dca/{num_dca}/col",
                 "output": "/dca/{num_dca}/config_color",
                 "input_padding": {"num_dca": 1},
-                "data_index": 0,
+                "data_index": 2,
                 "secondary_output": {
                     "_name": {
-                        "data_index": 0,
                         "forward_function": "wing_color_index_to_name",
                         "reverse_function": "wing_color_name_to_index",
                     },
@@ -349,10 +349,9 @@ class MixerTypeWING(MixerTypeBase):
                 "input": "/main/{num_mains}/$col",
                 "output": "/main/{num_mains}/config_color",
                 "input_padding": {"num_mains": 1},
-                "data_index": 0,
+                "data_index": 2,
                 "secondary_output": {
                     "_name": {
-                        "data_index": 0,
                         "forward_function": "wing_color_index_to_name",
                         "reverse_function": "wing_color_name_to_index",
                     },

--- a/behringer_mixer/utils.py
+++ b/behringer_mixer/utils.py
@@ -82,6 +82,7 @@ def db_to_linf(value, config):
 _wing_colors = [
     # WING color indices per remote protocol appendix:
     # 1..12 map to the names below; we additionally keep "OFF" at index 0.
+    # Newer firmware/tooling exposes additional indices; we include known values up to 18.
     "OFF",
     "GRAY_BLUE",
     "MEDIUM_BLUE",
@@ -90,14 +91,18 @@ _wing_colors = [
     "GREEN",
     "OLIVE_GREEN",
     "YELLOW",
-    "ORANGE",
+    "BROWN",
     "RED",
     "CORAL",
-    "PINK",
-    "MAUVE",
+    "MAGENTA",
+    "PURPLE",
+    "ORANGE",
+    "LIGHT_BLUE",
+    "SALMON",
+    "TEAL",
+    "DARK_GRAY",
+    "LIGHT_GRAY",
 ]
-
-
 
 
 def wing_color_name_to_index(color_name: str, config) -> int:

--- a/behringer_mixer/utils.py
+++ b/behringer_mixer/utils.py
@@ -80,6 +80,8 @@ def db_to_linf(value, config):
 
 
 _wing_colors = [
+    # WING color indices per remote protocol appendix:
+    # 1..12 map to the names below; we additionally keep "OFF" at index 0.
     "OFF",
     "GRAY_BLUE",
     "MEDIUM_BLUE",
@@ -96,11 +98,30 @@ _wing_colors = [
 ]
 
 
+
+
 def wing_color_name_to_index(color_name: str, config) -> int:
     """Convert color name to color index"""
-    return _wing_colors.index(color_name)
+    if color_name in _wing_colors:
+        return _wing_colors.index(color_name)
+    # Allow round-tripping unknown indices exposed as strings (e.g. "COLOR_14").
+    if isinstance(color_name, str) and color_name.startswith("COLOR_"):
+        suffix = color_name.removeprefix("COLOR_")
+        try:
+            return int(suffix)
+        except ValueError as err:
+            raise ValueError(f"Invalid WING color name: {color_name}") from err
+    raise ValueError(f"Unknown WING color name: {color_name}")
 
 
 def wing_color_index_to_name(color_index: int, config) -> str:
     """Convert color index to color name"""
-    return _wing_colors[int(color_index)]
+    try:
+        idx = int(color_index)
+    except (TypeError, ValueError):
+        return "UNKNOWN"
+
+    if 0 <= idx < len(_wing_colors):
+        return _wing_colors[idx]
+
+    return f"COLOR_{idx}"


### PR DESCRIPTION
This improves Behringer WING support with a few small but important protocol fixes:

- Corrects WING channel count to 40 (aux-ins are handled separately).
- Makes initial mixer info loading reliable by requesting /? and accepting the WING reply variant (/* vs /?) so /status populates consistently.
- Fixes WING mapping/value extraction by using the correct data_index for multi-value OSC replies (notably color/config messages), and normalizes a couple of WING-specific addresses/paddings for consistent mapping generation.
- Updates WING color handling: aligns known indices with documented values, adds newer indices used by firmware v3.1 and adds a forward-compatible fallback (COLOR_<n>) so unknown colors can round-trip without breaking.
- No changes to non-WING mixer types; no test changes.

Tested with Wing Rack firmware v 3.1 , Home Assistant 2026.1.0, ha-behringer-mixer v 0.1.19.  

Hope this helps.
Thx a lot for your work!