### PR TITLE
Wing improvements, added features and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VS Code
+.vscode/

--- a/behringer_mixer/mixer_base.py
+++ b/behringer_mixer/mixer_base.py
@@ -210,29 +210,8 @@ class MixerBase:
         if state_key:
             if "data_index" in address_data:
                 value = values[address_data["data_index"]]
-            mapping = address_data.get("mapping")
-            if mapping:
-                try:
-                    value = mapping.get(value)
-                except TypeError:
-                    pass
-            if address_data.get("data_type", "") == "int":
-                # WING often returns numbers as strings (e.g. "7").
-                # Guard for list/tuple payloads and unknown types.
-                scalar: Any = value
-                if isinstance(value, (list, tuple)):
-                    scalar = value[0] if value else None
-
-                if isinstance(scalar, bool):
-                    # Avoid True/False becoming 1/0 unless explicitly intended.
-                    pass
-                elif isinstance(scalar, (int, float)):
-                    value = int(scalar)
-                elif isinstance(scalar, str):
-                    try:
-                        value = int(float(scalar))
-                    except ValueError:
-                        pass
+            if address_data.get("mapping"):
+                value = address_data["mapping"].get(value)
             if address_data.get("data_type", "") == "boolean":
                 value = bool(value)
             if address_data.get("data_type", "") == "boolean_inverted":

--- a/behringer_mixer/mixer_base.py
+++ b/behringer_mixer/mixer_base.py
@@ -97,7 +97,7 @@ class MixerBase:
         if addr == "/xinfo":
             self.handle_xinfo(data)
             updates = []
-        # WING responds to the info query ("/?") with either "/?" or "/*" depending on firmwaren. 
+        # WING responds to the info query ("/?") with either "/?" or "/*" depending on firmware. 
         # Note: "/*" is also used for generic ACK/error strings (e.g. OK, NODE NOT FOUND).
         if addr in ("/*", "/?") and data and isinstance(data[0], str):
             if data[0].startswith("WING,"):

--- a/behringer_mixer/mixer_types.py
+++ b/behringer_mixer/mixer_types.py
@@ -3,6 +3,8 @@ from .mixers.mixer_type_xr18 import MixerTypeXR18
 from .mixers.mixer_type_xr16 import MixerTypeXR16
 from .mixers.mixer_type_xr12 import MixerTypeXR12
 from .mixers.mixer_type_wing import MixerTypeWING
+from .mixers.mixer_type_wing_rack import MixerTypeWINGRACK
+from .mixers.mixer_type_wing_compact import MixerTypeWINGCOMPACT
 
 _supported_mixers = [
     "X32",
@@ -10,6 +12,8 @@ _supported_mixers = [
     "XR16",
     "XR12",
     "WING",
+    "WINGRACK",
+    "WINGCOMPACT",
 ]
 
 
@@ -23,6 +27,8 @@ def make_mixer(mixer_type, **kwargs):
             "MixerTypeXR16": MixerTypeXR16,
             "MixerTypeXR12": MixerTypeXR12,
             "MixerTypeWING": MixerTypeWING,
+            "MixerTypeWINGRACK": MixerTypeWINGRACK,
+            "MixerTypeWINGCOMPACT": MixerTypeWINGCOMPACT,
         }
         mixer_class = mixer_class_map.get(mixer_class_name)
         if mixer_class:

--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -45,7 +45,7 @@ The notes below are based on:
         - phantom: `/headamp/<n>/phantom` and `/headamp/a|b|c/<n>/phantom`
         - name:    `/headamp/.../config_name`
         - color:   `/headamp/.../config_color`
-    - Phantom (`.../vph`) was writable and read back reliably.
+        - Phantom (`.../vph`) was writable and read back reliably.
         - Gain writes are accepted when Remote Lock is OFF and no competing OSC client is connected.
         - Effective gain step size on LCL inputs is 2.5 dB (matches console UI), not 0.5 dB as in
             some docs. Readbacks can occasionally time out on individual steps (likely timing/OSC drop).
@@ -62,23 +62,27 @@ The notes below are based on:
         - Write-tested (safe toggle/nudge + restore): inv, srcauto, altsrc, trim, bal,
             dlyon, dly, $vph. (Mode changes were not tested.)
 
-6) Sends and “self-sends”
+7) Sends and “self-sends”
     - Bus → bus sends where the source bus equals the destination bus are ignored by the console.
 
-7) `/status` is synthetic
+8) `/status` is synthetic
     - We query `/ ?` for mixer info, but store it under the synthetic output `/status`.
     - `/status` is not a real writable OSC endpoint.
 
-8) USB player playlist behavior
+9) USB player playlist behavior
         - `/play/$songs` returns the *first* song on a simple read. Use a node-level request
             (e.g. `/play/$songs` with value `?`) to retrieve the full playlist.
         - `/play/$actlist` points to the playlist file (e.g. `U:/SOUNDS/.plist`), not the folder.
-        - Many `/play/*` nodes respond only when a playlist is open on the console.
+        - Player actions (PLAY/PAUSE/STOP) return `ERROR` if no playlist/file is active.
+        - To play reliably: open a playlist on the console, set `/play/$actidx` and send `PLAY`.
 
-9) Conditional endpoints (USB recorder, show/library)
+10) Conditional endpoints (USB recorder, show/library)
         - Some `/usb/rec/*` and show/library endpoints are conditional on media/show state and may
-            time out even if the mapping is correct (e.g. `/usb/rec/path` when no medium is present).
-            TODO: Deep dive into which endpoints are always available vs conditional.
+            time out even if the mapping is correct.
+        - Observed: `/usb/rec/path` returned <no response> even with a USB stick inserted, while
+            `/usb/rec/state`, `/usb/rec/file`, `/usb/rec/time`, `/usb/rec/resolution`, `/usb/rec/channels`
+            were responsive.
+        - Recorder actions: `NEWFILE` → `REC` → `STOP` worked and created a new file.
 """
 
 from .mixer_type_base import MixerTypeBase

--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -46,9 +46,21 @@ The notes below are based on:
         - name:    `/headamp/.../config_name`
         - color:   `/headamp/.../config_color`
     - Phantom (`.../vph`) was writable and read back reliably.
-    - Gain writes are frequently ignored/locked depending on headamp ownership, source selection,
-      or "remote enable"/lock settings, or maybe just not functional like this.
-      TODO: Need to check if we just should use e.g.: /ch/*/in/set/$g instead / additionally.
+        - Gain writes are accepted when Remote Lock is OFF and no competing OSC client is connected.
+        - Effective gain step size on LCL inputs is 2.5 dB (matches console UI), not 0.5 dB as in
+            some docs. Readbacks can occasionally time out on individual steps (likely timing/OSC drop).
+        - Both `/io/in/LCL/<n>/g` and `/ch/<n>/in/set/$g` write paths work; use either depending on
+            whether you want the IO path or the channel path semantics.
+        - Stereo input pairs explain "missing" even LCL patches (e.g. 5/6, 7/8, 9/10...): the right
+            side often shows as unpatched even though it is part of a stereo pair.
+        - AES50 inputs return default values even with no stagebox connected; occasional empty fields
+            are expected (timing/response drop).
+
+6) Channel preamp settings (/ch/<n>/in/set/* and /ch/<n>/in/conn/*)
+        - Mapped and read-tested: $mode, srcauto, altsrc, inv, trim, bal, $g, $vph,
+            dlymode, dly, dlyon, conn grp/in, altgrp/altin.
+        - Write-tested (safe toggle/nudge + restore): inv, srcauto, altsrc, trim, bal,
+            dlyon, dly, $vph. (Mode changes were not tested.)
 
 6) Sends and “self-sends”
     - Bus → bus sends where the source bus equals the destination bus are ignored by the console.
@@ -153,6 +165,146 @@ class MixerTypeWING(MixerTypeBase):
                         "reverse_function": "wing_color_name_to_index",
                     },
                 },
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/$g",
+                "output": "/ch/{num_channel}/preamp_gain",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/$vph",
+                "output": "/ch/{num_channel}/preamp_phantom",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+                "data_type": "boolean",
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/$mode",
+                "output": "/ch/{num_channel}/input_mode",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/srcauto",
+                "output": "/ch/{num_channel}/input_srcauto",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+                "data_type": "boolean",
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/altsrc",
+                "output": "/ch/{num_channel}/input_altsrc",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+                "data_type": "boolean",
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/inv",
+                "output": "/ch/{num_channel}/input_invert",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+                "data_type": "boolean",
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/trim",
+                "output": "/ch/{num_channel}/input_trim",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/bal",
+                "output": "/ch/{num_channel}/input_balance",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/dlymode",
+                "output": "/ch/{num_channel}/input_delay_mode",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/dly",
+                "output": "/ch/{num_channel}/input_delay",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/set/dlyon",
+                "output": "/ch/{num_channel}/input_delay_on",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+                "data_type": "boolean",
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/conn/grp",
+                "output": "/ch/{num_channel}/input_conn_grp",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/conn/in",
+                "output": "/ch/{num_channel}/input_conn_in",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/conn/altgrp",
+                "output": "/ch/{num_channel}/input_alt_conn_grp",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
+            },
+            {
+                "tag": "channelpreamp",
+                "input": "/ch/{num_channel}/in/conn/altin",
+                "output": "/ch/{num_channel}/input_alt_conn_in",
+                "input_padding": {
+                    "num_channel": 1,
+                },
+                "data_index": 0,
             },
             # Channel Sends
             {

--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -40,7 +40,7 @@ The notes below are based on:
 5) Scribble strip light (LED)
     - `/ch/<n>/led` and `/aux/<n>/led` toggle the scribble light (0/1).
     - Mapped to `/ch/<n>/config_led` and `/auxin/<n>/config_led`.
-    - Field tests show no readback for `/.../led`. Treat as write-only.
+    - Field tests show readback does work on `/.../led` (returns multi-value tuples like other endpoints).
 
 6) Headamps: local (LCL) and AES50 (A/B/C)
     - Local headamps are addressed via `/io/in/LCL/<n>/...`.

--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -70,17 +70,21 @@ The notes below are based on:
         We only parse `/*` replies that start with `WING,`.
     - `/status` is not a real writable OSC endpoint.
 
-9) USB player playlist behavior
+9) USB player behavior
     - `/play/$songs` returns the first song on a simple read; use a node-level request
         (e.g. `/play/$songs` with value `?`) for the full playlist.
     - `/play/$actlist` points to the playlist file (e.g. `U:/SOUNDS/.plist`).
     - Actions can return `ERROR` if no playlist/file is active; to play reliably open a
-        playlist on the console, set `/play/$actidx`, then send `PLAY`.
+      playlist on the console (or set `/play/$actlist`), set `/play/$actidx`, then send `PLAY`.
+    - Playback was verified when a playlist was active (state moved to `PLAY`).
+    - Direct file playback works via `/play/$playfile` + `PLAYFILE`, even without playlist metadata.
+    - `/usb/playlist/songs` may return an empty string or a single string entry; normalize to a list.
 
 10) USB recorder behavior
     - Check `/usb/rec/state` and `/usb/rec/file`.
     - Trigger actions via `/usb/rec/action` (values: NEWFILE, REC, STOP, PAUSE).
     - Recorder actions: `NEWFILE` → `REC` → `STOP` worked and created a new file.
+    - PAUSE freezes `/usb/rec/time` and resume continues the counter.
     - `/usb/rec/path` was removed.
 
 """

--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -178,6 +178,7 @@ class MixerTypeWING(MixerTypeBase):
                     "num_channel": 1,
                 },
                 "data_index": 0,
+                "write_transform": "wing_headamp_gain_db_to_float",
             },
             {
                 "tag": "channelpreamp",
@@ -732,6 +733,7 @@ class MixerTypeWING(MixerTypeBase):
                 "input": "/io/in/LCL/{num_head_amp}/g",
                 "output": "/headamp/{num_head_amp}/gain",
                 "data_index": 2,
+                "write_transform": "wing_headamp_gain_db_to_float",
                 "secondary_output": {
                     "_db": {
                         "data_index": 0,
@@ -782,6 +784,7 @@ class MixerTypeWING(MixerTypeBase):
                 "input": "/io/in/A/{num_aes50_in}/g",
                 "output": "/headamp/a/{num_aes50_in}/gain",
                 "data_index": 2,
+                "write_transform": "wing_headamp_gain_db_to_float",
                 "secondary_output": {
                     "_db": {
                         "data_index": 0,
@@ -830,6 +833,7 @@ class MixerTypeWING(MixerTypeBase):
                 "input": "/io/in/B/{num_aes50_in}/g",
                 "output": "/headamp/b/{num_aes50_in}/gain",
                 "data_index": 2,
+                "write_transform": "wing_headamp_gain_db_to_float",
                 "secondary_output": {
                     "_db": {
                         "data_index": 0,
@@ -878,6 +882,7 @@ class MixerTypeWING(MixerTypeBase):
                 "input": "/io/in/C/{num_aes50_in}/g",
                 "output": "/headamp/c/{num_aes50_in}/gain",
                 "data_index": 2,
+                "write_transform": "wing_headamp_gain_db_to_float",
                 "secondary_output": {
                     "_db": {
                         "data_index": 0,

--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -57,10 +57,16 @@ The notes below are based on:
     - We query `/ ?` for mixer info, but store it under the synthetic output `/status`.
     - `/status` is not a real writable OSC endpoint.
 
-8) Conditional endpoints (USB recorder, show/library)
-    - Some `/usb/rec/*` and show/library endpoints are conditional on media/show state and may
-      time out even if the mapping is correct (e.g. `/usb/rec/path` when no medium is present).
-      TODO: Deep dive into which endpoints are always available vs conditional.
+8) USB player playlist behavior
+        - `/play/$songs` returns the *first* song on a simple read. Use a node-level request
+            (e.g. `/play/$songs` with value `?`) to retrieve the full playlist.
+        - `/play/$actlist` points to the playlist file (e.g. `U:/SOUNDS/.plist`), not the folder.
+        - Many `/play/*` nodes respond only when a playlist is open on the console.
+
+9) Conditional endpoints (USB recorder, show/library)
+        - Some `/usb/rec/*` and show/library endpoints are conditional on media/show state and may
+            time out even if the mapping is correct (e.g. `/usb/rec/path` when no medium is present).
+            TODO: Deep dive into which endpoints are always available vs conditional.
 """
 
 from .mixer_type_base import MixerTypeBase
@@ -480,6 +486,22 @@ class MixerTypeWING(MixerTypeBase):
                 "tag": "usb",
                 "input": "/play/$actfile",
                 "output": "/usb/file",
+            },
+            {
+                "tag": "usb",
+                "input": "/play/$actlist",
+                "output": "/usb/playlist/path",
+            },
+            {
+                "tag": "usb",
+                "input": "/play/$actidx",
+                "output": "/usb/playlist/index",
+                "data_index": 0,
+            },
+            {
+                "tag": "usb",
+                "input": "/play/$songs",
+                "output": "/usb/playlist/songs",
             },
 
             # USB Recorder

--- a/behringer_mixer/mixers/mixer_type_wing.py
+++ b/behringer_mixer/mixers/mixer_type_wing.py
@@ -8,13 +8,15 @@ class MixerTypeWING(MixerTypeBase):
     mixer_type: str = "WING"
     num_channel: int = 40
     num_bus: int = 16
+    num_bus_send: int = 16
     num_dca: int = 16
     num_fx: int = 0
     num_auxin: int = 8
     num_auxrtn: int = 0
     num_matrix: int = 8
     has_mono: bool = False
-    num_head_amp: int = 0
+    num_head_amp: int = 8
+    num_aes50_in: int = 48
     num_mains: int = 4
     num_mute_groups: int = 8
     info_address: str = "/?"
@@ -212,6 +214,44 @@ class MixerTypeWING(MixerTypeBase):
                     },
                 },
             },
+            {
+                "tag": "bussends",
+                "input": "/bus/{num_bus}/send/MX{num_matrix}/pre",
+                "input_padding": {"num_matrix": 1, "num_bus": 1},
+                "output": "/bussend/{num_bus}/{num_matrix}/pre",
+                "data_type": "boolean",
+                "data_index": 2,
+            },
+            # Bus -> Bus Sends (WING allows self-sends)
+            {
+                "tag": "busbussends",
+                "input": "/bus/{num_bus}/send/{num_bus_send}/on",
+                "input_padding": {"num_bus": 1, "num_bus_send": 1},
+                "output": "/busbussend/{num_bus}/{num_bus_send}/mix_on",
+                "data_type": "boolean",
+                "data_index": 2,
+            },
+            {
+                "tag": "busbussends",
+                "input": "/bus/{num_bus}/send/{num_bus_send}/lvl",
+                "input_padding": {"num_bus": 1, "num_bus_send": 1},
+                "output": "/busbussend/{num_bus}/{num_bus_send}/mix_fader",
+                "write_transform": "fader_to_db",
+                "data_index": 1,
+                "secondary_output": {
+                    "_db": {
+                        "data_index": 0,
+                    },
+                },
+            },
+            {
+                "tag": "busbussends",
+                "input": "/bus/{num_bus}/send/{num_bus_send}/pre",
+                "input_padding": {"num_bus": 1, "num_bus_send": 1},
+                "output": "/busbussend/{num_bus}/{num_bus_send}/pre",
+                "data_type": "boolean",
+                "data_index": 2,
+            },
             # Bus Mains Sends
             {
                 "tag": "busmainsends",
@@ -233,6 +273,14 @@ class MixerTypeWING(MixerTypeBase):
                         "data_index": 0,
                     },
                 },
+            },
+            {
+                "tag": "busmainsends",
+                "input": "/bus/{num_bus}/main/{num_mains}/pre",
+                "input_padding": {"num_mains": 1, "num_bus": 1},
+                "output": "/busmainsend/{num_bus}/{num_mains}/pre",
+                "data_type": "boolean",
+                "data_index": 2,
             },
             # Matrices
             {
@@ -393,6 +441,65 @@ class MixerTypeWING(MixerTypeBase):
                 "input": "/play/$actfile",
                 "output": "/usb/file",
             },
+
+            # USB Recorder
+            {
+                "tag": "usbrec",
+                "input": "/rec/$actstate",
+                "output": "/usb/rec/state",
+                # WING may return enum indices or strings depending on firmware;
+                # include identity entries to avoid mapping to None.
+                "mapping": {
+                    0: "STOP",
+                    1: "REC",
+                    2: "PAUSE",
+                    3: "ERROR",
+                    "STOP": "STOP",
+                    "REC": "REC",
+                    "PAUSE": "PAUSE",
+                    "ERROR": "ERROR",
+                },
+            },
+            {
+                "tag": "usbrec",
+                "input": "/rec/$actfile",
+                "output": "/usb/rec/file",
+            },
+            {
+                "tag": "usbrec",
+                "input": "/rec/$action",
+                "output": "/usb/rec/action",
+                "mapping": {
+                    0: "STOP",
+                    1: "REC",
+                    2: "PAUSE",
+                    3: "NEWFILE",
+                    "STOP": "STOP",
+                    "REC": "REC",
+                    "PAUSE": "PAUSE",
+                    "NEWFILE": "NEWFILE",
+                },
+            },
+            {
+                "tag": "usbrec",
+                "input": "/rec/path",
+                "output": "/usb/rec/path",
+            },
+            {
+                "tag": "usbrec",
+                "input": "/rec/resolution",
+                "output": "/usb/rec/resolution",
+            },
+            {
+                "tag": "usbrec",
+                "input": "/rec/channels",
+                "output": "/usb/rec/channels",
+            },
+            {
+                "tag": "usbrec",
+                "input": "/rec/$time",
+                "output": "/usb/rec/time",
+            },
             # Mute Groups
             {
                 "tag": "mutegroups",
@@ -400,6 +507,205 @@ class MixerTypeWING(MixerTypeBase):
                 "output": "/mutegroups/{num_mute_groups}/on",
                 "data_type": "boolean",
                 "data_index": 2,
+            },
+            # Headamps (local sources)
+            {
+                "tag": "headamps",
+                "input": "/io/in/LCL/{num_head_amp}/g",
+                "output": "/headamp/{num_head_amp}/gain",
+                "input_padding": {
+                    "num_head_amp": 1,
+                },
+                "write_transform": "wing_headamp_gain_db_to_float",
+                "data_index": 2,
+                "secondary_output": {
+                    "_db": {
+                        "forward_function": "float_to_db",
+                        "reverse_function": "db_to_float",
+                    },
+                },
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/LCL/{num_head_amp}/vph",
+                "output": "/headamp/{num_head_amp}/phantom",
+                "input_padding": {
+                    "num_head_amp": 1,
+                },
+                "data_type": "boolean",
+                "data_index": 2,
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/LCL/{num_head_amp}/name",
+                "output": "/headamp/{num_head_amp}/config_name",
+                "input_padding": {
+                    "num_head_amp": 1,
+                },
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/LCL/{num_head_amp}/col",
+                "output": "/headamp/{num_head_amp}/config_color",
+                "input_padding": {
+                    "num_head_amp": 1,
+                },
+                "data_index": 2,
+                "secondary_output": {
+                    "_name": {
+                        "forward_function": "wing_color_index_to_name",
+                        "reverse_function": "wing_color_name_to_index",
+                    },
+                },
+            },
+
+            # Headamps (AES50 A/B/C sources)
+            {
+                "tag": "headamps",
+                "input": "/io/in/A/{num_aes50_in}/g",
+                "output": "/headamp/a/{num_aes50_in}/gain",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+                "write_transform": "wing_headamp_gain_db_to_float",
+                "data_index": 2,
+                "secondary_output": {
+                    "_db": {
+                        "forward_function": "float_to_db",
+                        "reverse_function": "db_to_float",
+                    },
+                },
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/A/{num_aes50_in}/vph",
+                "output": "/headamp/a/{num_aes50_in}/phantom",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+                "data_type": "boolean",
+                "data_index": 2,
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/A/{num_aes50_in}/name",
+                "output": "/headamp/a/{num_aes50_in}/config_name",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/A/{num_aes50_in}/col",
+                "output": "/headamp/a/{num_aes50_in}/config_color",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+                "data_index": 2,
+                "secondary_output": {
+                    "_name": {
+                        "forward_function": "wing_color_index_to_name",
+                        "reverse_function": "wing_color_name_to_index",
+                    },
+                },
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/B/{num_aes50_in}/g",
+                "output": "/headamp/b/{num_aes50_in}/gain",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+                "write_transform": "wing_headamp_gain_db_to_float",
+                "data_index": 2,
+                "secondary_output": {
+                    "_db": {
+                        "forward_function": "float_to_db",
+                        "reverse_function": "db_to_float",
+                    },
+                },
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/B/{num_aes50_in}/vph",
+                "output": "/headamp/b/{num_aes50_in}/phantom",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+                "data_type": "boolean",
+                "data_index": 2,
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/B/{num_aes50_in}/name",
+                "output": "/headamp/b/{num_aes50_in}/config_name",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/B/{num_aes50_in}/col",
+                "output": "/headamp/b/{num_aes50_in}/config_color",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+                "data_index": 2,
+                "secondary_output": {
+                    "_name": {
+                        "forward_function": "wing_color_index_to_name",
+                        "reverse_function": "wing_color_name_to_index",
+                    },
+                },
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/C/{num_aes50_in}/g",
+                "output": "/headamp/c/{num_aes50_in}/gain",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+                "write_transform": "wing_headamp_gain_db_to_float",
+                "data_index": 2,
+                "secondary_output": {
+                    "_db": {
+                        "forward_function": "float_to_db",
+                        "reverse_function": "db_to_float",
+                    },
+                },
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/C/{num_aes50_in}/vph",
+                "output": "/headamp/c/{num_aes50_in}/phantom",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+                "data_type": "boolean",
+                "data_index": 2,
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/C/{num_aes50_in}/name",
+                "output": "/headamp/c/{num_aes50_in}/config_name",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+            },
+            {
+                "tag": "headamps",
+                "input": "/io/in/C/{num_aes50_in}/col",
+                "output": "/headamp/c/{num_aes50_in}/config_color",
+                "input_padding": {
+                    "num_aes50_in": 1,
+                },
+                "data_index": 2,
+                "secondary_output": {
+                    "_name": {
+                        "forward_function": "wing_color_index_to_name",
+                        "reverse_function": "wing_color_name_to_index",
+                    },
+                },
             },
         ]
 

--- a/behringer_mixer/mixers/mixer_type_wing_compact.py
+++ b/behringer_mixer/mixers/mixer_type_wing_compact.py
@@ -1,0 +1,8 @@
+from .mixer_type_wing import MixerTypeWING
+
+
+class MixerTypeWINGCOMPACT(MixerTypeWING):
+    """Class for Behringer WING Compact Mixer"""
+
+    mixer_type: str = "WINGCOMPACT"
+    num_head_amp: int = 24

--- a/behringer_mixer/mixers/mixer_type_wing_rack.py
+++ b/behringer_mixer/mixers/mixer_type_wing_rack.py
@@ -1,0 +1,8 @@
+from .mixer_type_wing import MixerTypeWING
+
+
+class MixerTypeWINGRACK(MixerTypeWING):
+    """Class for Behringer WING Rack Mixer"""
+
+    mixer_type: str = "WINGRACK"
+    num_head_amp: int = 24

--- a/behringer_mixer/utils.py
+++ b/behringer_mixer/utils.py
@@ -152,15 +152,15 @@ def db_to_float(value, config):
 def wing_headamp_gain_db_to_float(value, config):
     """Normalize WING headamp gain values.
 
-    Per WING OSC documentation, local headamp gain is a float with range
-    -3.0 .. 45.5 dB in 98 discrete steps (0.5 dB increments).
+    Field tests show local headamp gain uses 2.5 dB steps and a range
+    of -2.5 .. 45.0 dB on current firmware (docs claim 0.5 dB).
     """
     try:
         gain_db = float(value)
     except (TypeError, ValueError):
         raise ValueError(f"Invalid headamp gain value: {value!r}")
 
-    gain_db = max(-3.0, min(45.5, gain_db))
-    gain_db = round(gain_db * 2.0) / 2.0
-    gain_db = max(-3.0, min(45.5, gain_db))
+    gain_db = max(-2.5, min(45.0, gain_db))
+    gain_db = round(gain_db / 2.5) * 2.5
+    gain_db = max(-2.5, min(45.0, gain_db))
     return gain_db

--- a/behringer_mixer/utils.py
+++ b/behringer_mixer/utils.py
@@ -81,8 +81,8 @@ def db_to_linf(value, config):
 
 _wing_colors = [
     # WING firmware >= 3.1 exposes 18 colors.
-    # OSC returns (string, normalized, int) where the string value is 1-based.
-    # 0-based list of the 18 color names, convert at the boundary.
+    # OSC returns (string, normalized, int). String is 1-based, int is 0-based.
+    # 0-based list of the 18 color names.
     "GRAY_BLUE",
     "MEDIUM_BLUE",
     "DARK_BLUE",
@@ -107,31 +107,28 @@ _wing_colors = [
 def wing_color_name_to_index(color_name: str, config) -> int:
     """Convert color name to color index"""
     if color_name in _wing_colors:
-        return _wing_colors.index(color_name) + 1
-    # Allow round-tripping unknown indices exposed as strings (e.g. "COLOR_14").
-    if isinstance(color_name, str) and color_name.startswith("COLOR_"):
-        suffix = color_name.removeprefix("COLOR_")
-        try:
-            # Treat this as an external 1-based index.
-            return int(suffix)
-        except ValueError as err:
-            raise ValueError(f"Invalid WING color name: {color_name}") from err
+        return _wing_colors.index(color_name)
     raise ValueError(f"Unknown WING color name: {color_name}")
 
 
 def wing_color_index_to_name(color_index: int, config) -> str:
     """Convert color index to color name"""
+    if 0 <= color_index < len(_wing_colors):
+        return _wing_colors[color_index]
+    raise ValueError(f"Unknown WING color index: {color_index}")
+
+
+def wing_color_index_to_device(color_index: int, config) -> int:
+    """Convert internal 0-based color index to WING's 1-based write value."""
     try:
         idx = int(float(color_index))
-    except (TypeError, ValueError):
-        return "UNKNOWN"
+    except (TypeError, ValueError) as err:
+        raise ValueError(f"Invalid WING color index: {color_index}") from err
 
-    # External is 1-based; convert to internal 0-based.
-    idx0 = idx - 1
-    if 0 <= idx0 < len(_wing_colors):
-        return _wing_colors[idx0]
+    if idx < 0 or idx >= len(_wing_colors):
+        raise ValueError(f"Unknown WING color index: {idx}")
 
-    return f"COLOR_{idx}"
+    return idx + 1
 
 
 def float_to_db(value, config):

--- a/behringer_mixer/utils.py
+++ b/behringer_mixer/utils.py
@@ -130,3 +130,30 @@ def wing_color_index_to_name(color_index: int, config) -> str:
         return _wing_colors[idx]
 
     return f"COLOR_{idx}"
+
+
+def float_to_db(value, config):
+    """Pass-through conversion for values that are already in dB."""
+    return value
+
+
+def db_to_float(value, config):
+    """Inverse of float_to_db (pass-through)."""
+    return value
+
+
+def wing_headamp_gain_db_to_float(value, config):
+    """Normalize WING headamp gain values.
+
+    Per WING OSC documentation, local headamp gain is a float with range
+    -3.0 .. 45.5 dB in 98 discrete steps (0.5 dB increments).
+    """
+    try:
+        gain_db = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"Invalid headamp gain value: {value!r}")
+
+    gain_db = max(-3.0, min(45.5, gain_db))
+    gain_db = round(gain_db * 2.0) / 2.0
+    gain_db = max(-3.0, min(45.5, gain_db))
+    return gain_db

--- a/behringer_mixer/utils.py
+++ b/behringer_mixer/utils.py
@@ -106,8 +106,6 @@ _wing_colors = [
 
 def wing_color_name_to_index(color_name: str, config) -> int:
     """Convert color name to color index"""
-    if color_name == "OFF":
-        return 0
     if color_name in _wing_colors:
         return _wing_colors.index(color_name) + 1
     # Allow round-tripping unknown indices exposed as strings (e.g. "COLOR_14").
@@ -127,9 +125,6 @@ def wing_color_index_to_name(color_index: int, config) -> str:
         idx = int(float(color_index))
     except (TypeError, ValueError):
         return "UNKNOWN"
-
-    if idx == 0:
-        return "OFF"
 
     # External is 1-based; convert to internal 0-based.
     idx0 = idx - 1

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -26,3 +26,14 @@ async def test_mixer_xr16():
         existing = json.dumps(json_data)
         print(mapping)
         assert mapping == existing
+
+
+@pytest.mark.asyncio
+async def test_mixer_wing():
+    # Open and read the JSON file
+    with open("tests/wingmapping.json", "r") as file:
+        json_data = json.load(file)
+        mixer = mixer_api.create("WING", ip="192.168.1.1")
+        mapping = json.dumps(mixer.dump_mapping())
+        existing = json.dumps(json_data)
+        assert mapping == existing

--- a/tests/wingmapping.json
+++ b/tests/wingmapping.json
@@ -1,0 +1,16710 @@
+[
+    {
+        "input": "/$ctl/lib/$actidx",
+        "output": "/scene/current"
+    },
+    {
+        "input": "/$ctl/lib/$actionidx",
+        "output": "/scene/next_scene"
+    },
+    {
+        "input": "/$ctl/lib/$active",
+        "output": "/scene/name"
+    },
+    {
+        "input": "/$ctl/lib/$actshow",
+        "output": "/show/name"
+    },
+    {
+        "input": "/?",
+        "output": "/status"
+    },
+    {
+        "input": "/aux/1/col",
+        "output": "/auxin/1/config_color"
+    },
+    {
+        "input": "/aux/1/fdr",
+        "output": "/auxin/1/mix_fader"
+    },
+    {
+        "input": "/aux/1/mute",
+        "output": "/auxin/1/mix_on"
+    },
+    {
+        "input": "/aux/1/name",
+        "output": "/auxin/1/config_name"
+    },
+    {
+        "input": "/aux/2/col",
+        "output": "/auxin/2/config_color"
+    },
+    {
+        "input": "/aux/2/fdr",
+        "output": "/auxin/2/mix_fader"
+    },
+    {
+        "input": "/aux/2/mute",
+        "output": "/auxin/2/mix_on"
+    },
+    {
+        "input": "/aux/2/name",
+        "output": "/auxin/2/config_name"
+    },
+    {
+        "input": "/aux/3/col",
+        "output": "/auxin/3/config_color"
+    },
+    {
+        "input": "/aux/3/fdr",
+        "output": "/auxin/3/mix_fader"
+    },
+    {
+        "input": "/aux/3/mute",
+        "output": "/auxin/3/mix_on"
+    },
+    {
+        "input": "/aux/3/name",
+        "output": "/auxin/3/config_name"
+    },
+    {
+        "input": "/aux/4/col",
+        "output": "/auxin/4/config_color"
+    },
+    {
+        "input": "/aux/4/fdr",
+        "output": "/auxin/4/mix_fader"
+    },
+    {
+        "input": "/aux/4/mute",
+        "output": "/auxin/4/mix_on"
+    },
+    {
+        "input": "/aux/4/name",
+        "output": "/auxin/4/config_name"
+    },
+    {
+        "input": "/aux/5/col",
+        "output": "/auxin/5/config_color"
+    },
+    {
+        "input": "/aux/5/fdr",
+        "output": "/auxin/5/mix_fader"
+    },
+    {
+        "input": "/aux/5/mute",
+        "output": "/auxin/5/mix_on"
+    },
+    {
+        "input": "/aux/5/name",
+        "output": "/auxin/5/config_name"
+    },
+    {
+        "input": "/aux/6/col",
+        "output": "/auxin/6/config_color"
+    },
+    {
+        "input": "/aux/6/fdr",
+        "output": "/auxin/6/mix_fader"
+    },
+    {
+        "input": "/aux/6/mute",
+        "output": "/auxin/6/mix_on"
+    },
+    {
+        "input": "/aux/6/name",
+        "output": "/auxin/6/config_name"
+    },
+    {
+        "input": "/aux/7/col",
+        "output": "/auxin/7/config_color"
+    },
+    {
+        "input": "/aux/7/fdr",
+        "output": "/auxin/7/mix_fader"
+    },
+    {
+        "input": "/aux/7/mute",
+        "output": "/auxin/7/mix_on"
+    },
+    {
+        "input": "/aux/7/name",
+        "output": "/auxin/7/config_name"
+    },
+    {
+        "input": "/aux/8/col",
+        "output": "/auxin/8/config_color"
+    },
+    {
+        "input": "/aux/8/fdr",
+        "output": "/auxin/8/mix_fader"
+    },
+    {
+        "input": "/aux/8/mute",
+        "output": "/auxin/8/mix_on"
+    },
+    {
+        "input": "/aux/8/name",
+        "output": "/auxin/8/config_name"
+    },
+    {
+        "input": "/bus/1/col",
+        "output": "/bus/1/config_color"
+    },
+    {
+        "input": "/bus/1/fdr",
+        "output": "/bus/1/mix_fader"
+    },
+    {
+        "input": "/bus/1/main/1/lvl",
+        "output": "/busmainsend/1/1/mix_fader"
+    },
+    {
+        "input": "/bus/1/main/1/on",
+        "output": "/busmainsend/1/1/mix_on"
+    },
+    {
+        "input": "/bus/1/main/1/pre",
+        "output": "/busmainsend/1/1/pre"
+    },
+    {
+        "input": "/bus/1/main/2/lvl",
+        "output": "/busmainsend/1/2/mix_fader"
+    },
+    {
+        "input": "/bus/1/main/2/on",
+        "output": "/busmainsend/1/2/mix_on"
+    },
+    {
+        "input": "/bus/1/main/2/pre",
+        "output": "/busmainsend/1/2/pre"
+    },
+    {
+        "input": "/bus/1/main/3/lvl",
+        "output": "/busmainsend/1/3/mix_fader"
+    },
+    {
+        "input": "/bus/1/main/3/on",
+        "output": "/busmainsend/1/3/mix_on"
+    },
+    {
+        "input": "/bus/1/main/3/pre",
+        "output": "/busmainsend/1/3/pre"
+    },
+    {
+        "input": "/bus/1/main/4/lvl",
+        "output": "/busmainsend/1/4/mix_fader"
+    },
+    {
+        "input": "/bus/1/main/4/on",
+        "output": "/busmainsend/1/4/mix_on"
+    },
+    {
+        "input": "/bus/1/main/4/pre",
+        "output": "/busmainsend/1/4/pre"
+    },
+    {
+        "input": "/bus/1/mute",
+        "output": "/bus/1/mix_on"
+    },
+    {
+        "input": "/bus/1/name",
+        "output": "/bus/1/config_name"
+    },
+    {
+        "input": "/bus/1/send/10/lvl",
+        "output": "/busbussend/1/10/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/10/on",
+        "output": "/busbussend/1/10/mix_on"
+    },
+    {
+        "input": "/bus/1/send/10/pre",
+        "output": "/busbussend/1/10/pre"
+    },
+    {
+        "input": "/bus/1/send/11/lvl",
+        "output": "/busbussend/1/11/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/11/on",
+        "output": "/busbussend/1/11/mix_on"
+    },
+    {
+        "input": "/bus/1/send/11/pre",
+        "output": "/busbussend/1/11/pre"
+    },
+    {
+        "input": "/bus/1/send/12/lvl",
+        "output": "/busbussend/1/12/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/12/on",
+        "output": "/busbussend/1/12/mix_on"
+    },
+    {
+        "input": "/bus/1/send/12/pre",
+        "output": "/busbussend/1/12/pre"
+    },
+    {
+        "input": "/bus/1/send/13/lvl",
+        "output": "/busbussend/1/13/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/13/on",
+        "output": "/busbussend/1/13/mix_on"
+    },
+    {
+        "input": "/bus/1/send/13/pre",
+        "output": "/busbussend/1/13/pre"
+    },
+    {
+        "input": "/bus/1/send/14/lvl",
+        "output": "/busbussend/1/14/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/14/on",
+        "output": "/busbussend/1/14/mix_on"
+    },
+    {
+        "input": "/bus/1/send/14/pre",
+        "output": "/busbussend/1/14/pre"
+    },
+    {
+        "input": "/bus/1/send/15/lvl",
+        "output": "/busbussend/1/15/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/15/on",
+        "output": "/busbussend/1/15/mix_on"
+    },
+    {
+        "input": "/bus/1/send/15/pre",
+        "output": "/busbussend/1/15/pre"
+    },
+    {
+        "input": "/bus/1/send/16/lvl",
+        "output": "/busbussend/1/16/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/16/on",
+        "output": "/busbussend/1/16/mix_on"
+    },
+    {
+        "input": "/bus/1/send/16/pre",
+        "output": "/busbussend/1/16/pre"
+    },
+    {
+        "input": "/bus/1/send/2/lvl",
+        "output": "/busbussend/1/2/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/2/on",
+        "output": "/busbussend/1/2/mix_on"
+    },
+    {
+        "input": "/bus/1/send/2/pre",
+        "output": "/busbussend/1/2/pre"
+    },
+    {
+        "input": "/bus/1/send/3/lvl",
+        "output": "/busbussend/1/3/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/3/on",
+        "output": "/busbussend/1/3/mix_on"
+    },
+    {
+        "input": "/bus/1/send/3/pre",
+        "output": "/busbussend/1/3/pre"
+    },
+    {
+        "input": "/bus/1/send/4/lvl",
+        "output": "/busbussend/1/4/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/4/on",
+        "output": "/busbussend/1/4/mix_on"
+    },
+    {
+        "input": "/bus/1/send/4/pre",
+        "output": "/busbussend/1/4/pre"
+    },
+    {
+        "input": "/bus/1/send/5/lvl",
+        "output": "/busbussend/1/5/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/5/on",
+        "output": "/busbussend/1/5/mix_on"
+    },
+    {
+        "input": "/bus/1/send/5/pre",
+        "output": "/busbussend/1/5/pre"
+    },
+    {
+        "input": "/bus/1/send/6/lvl",
+        "output": "/busbussend/1/6/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/6/on",
+        "output": "/busbussend/1/6/mix_on"
+    },
+    {
+        "input": "/bus/1/send/6/pre",
+        "output": "/busbussend/1/6/pre"
+    },
+    {
+        "input": "/bus/1/send/7/lvl",
+        "output": "/busbussend/1/7/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/7/on",
+        "output": "/busbussend/1/7/mix_on"
+    },
+    {
+        "input": "/bus/1/send/7/pre",
+        "output": "/busbussend/1/7/pre"
+    },
+    {
+        "input": "/bus/1/send/8/lvl",
+        "output": "/busbussend/1/8/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/8/on",
+        "output": "/busbussend/1/8/mix_on"
+    },
+    {
+        "input": "/bus/1/send/8/pre",
+        "output": "/busbussend/1/8/pre"
+    },
+    {
+        "input": "/bus/1/send/9/lvl",
+        "output": "/busbussend/1/9/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/9/on",
+        "output": "/busbussend/1/9/mix_on"
+    },
+    {
+        "input": "/bus/1/send/9/pre",
+        "output": "/busbussend/1/9/pre"
+    },
+    {
+        "input": "/bus/1/send/MX1/lvl",
+        "output": "/bussend/1/1/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/MX1/on",
+        "output": "/bussend/1/1/mix_on"
+    },
+    {
+        "input": "/bus/1/send/MX1/pre",
+        "output": "/bussend/1/1/pre"
+    },
+    {
+        "input": "/bus/1/send/MX2/lvl",
+        "output": "/bussend/1/2/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/MX2/on",
+        "output": "/bussend/1/2/mix_on"
+    },
+    {
+        "input": "/bus/1/send/MX2/pre",
+        "output": "/bussend/1/2/pre"
+    },
+    {
+        "input": "/bus/1/send/MX3/lvl",
+        "output": "/bussend/1/3/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/MX3/on",
+        "output": "/bussend/1/3/mix_on"
+    },
+    {
+        "input": "/bus/1/send/MX3/pre",
+        "output": "/bussend/1/3/pre"
+    },
+    {
+        "input": "/bus/1/send/MX4/lvl",
+        "output": "/bussend/1/4/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/MX4/on",
+        "output": "/bussend/1/4/mix_on"
+    },
+    {
+        "input": "/bus/1/send/MX4/pre",
+        "output": "/bussend/1/4/pre"
+    },
+    {
+        "input": "/bus/1/send/MX5/lvl",
+        "output": "/bussend/1/5/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/MX5/on",
+        "output": "/bussend/1/5/mix_on"
+    },
+    {
+        "input": "/bus/1/send/MX5/pre",
+        "output": "/bussend/1/5/pre"
+    },
+    {
+        "input": "/bus/1/send/MX6/lvl",
+        "output": "/bussend/1/6/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/MX6/on",
+        "output": "/bussend/1/6/mix_on"
+    },
+    {
+        "input": "/bus/1/send/MX6/pre",
+        "output": "/bussend/1/6/pre"
+    },
+    {
+        "input": "/bus/1/send/MX7/lvl",
+        "output": "/bussend/1/7/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/MX7/on",
+        "output": "/bussend/1/7/mix_on"
+    },
+    {
+        "input": "/bus/1/send/MX7/pre",
+        "output": "/bussend/1/7/pre"
+    },
+    {
+        "input": "/bus/1/send/MX8/lvl",
+        "output": "/bussend/1/8/mix_fader"
+    },
+    {
+        "input": "/bus/1/send/MX8/on",
+        "output": "/bussend/1/8/mix_on"
+    },
+    {
+        "input": "/bus/1/send/MX8/pre",
+        "output": "/bussend/1/8/pre"
+    },
+    {
+        "input": "/bus/10/col",
+        "output": "/bus/10/config_color"
+    },
+    {
+        "input": "/bus/10/fdr",
+        "output": "/bus/10/mix_fader"
+    },
+    {
+        "input": "/bus/10/main/1/lvl",
+        "output": "/busmainsend/10/1/mix_fader"
+    },
+    {
+        "input": "/bus/10/main/1/on",
+        "output": "/busmainsend/10/1/mix_on"
+    },
+    {
+        "input": "/bus/10/main/1/pre",
+        "output": "/busmainsend/10/1/pre"
+    },
+    {
+        "input": "/bus/10/main/2/lvl",
+        "output": "/busmainsend/10/2/mix_fader"
+    },
+    {
+        "input": "/bus/10/main/2/on",
+        "output": "/busmainsend/10/2/mix_on"
+    },
+    {
+        "input": "/bus/10/main/2/pre",
+        "output": "/busmainsend/10/2/pre"
+    },
+    {
+        "input": "/bus/10/main/3/lvl",
+        "output": "/busmainsend/10/3/mix_fader"
+    },
+    {
+        "input": "/bus/10/main/3/on",
+        "output": "/busmainsend/10/3/mix_on"
+    },
+    {
+        "input": "/bus/10/main/3/pre",
+        "output": "/busmainsend/10/3/pre"
+    },
+    {
+        "input": "/bus/10/main/4/lvl",
+        "output": "/busmainsend/10/4/mix_fader"
+    },
+    {
+        "input": "/bus/10/main/4/on",
+        "output": "/busmainsend/10/4/mix_on"
+    },
+    {
+        "input": "/bus/10/main/4/pre",
+        "output": "/busmainsend/10/4/pre"
+    },
+    {
+        "input": "/bus/10/mute",
+        "output": "/bus/10/mix_on"
+    },
+    {
+        "input": "/bus/10/name",
+        "output": "/bus/10/config_name"
+    },
+    {
+        "input": "/bus/10/send/1/lvl",
+        "output": "/busbussend/10/1/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/1/on",
+        "output": "/busbussend/10/1/mix_on"
+    },
+    {
+        "input": "/bus/10/send/1/pre",
+        "output": "/busbussend/10/1/pre"
+    },
+    {
+        "input": "/bus/10/send/11/lvl",
+        "output": "/busbussend/10/11/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/11/on",
+        "output": "/busbussend/10/11/mix_on"
+    },
+    {
+        "input": "/bus/10/send/11/pre",
+        "output": "/busbussend/10/11/pre"
+    },
+    {
+        "input": "/bus/10/send/12/lvl",
+        "output": "/busbussend/10/12/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/12/on",
+        "output": "/busbussend/10/12/mix_on"
+    },
+    {
+        "input": "/bus/10/send/12/pre",
+        "output": "/busbussend/10/12/pre"
+    },
+    {
+        "input": "/bus/10/send/13/lvl",
+        "output": "/busbussend/10/13/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/13/on",
+        "output": "/busbussend/10/13/mix_on"
+    },
+    {
+        "input": "/bus/10/send/13/pre",
+        "output": "/busbussend/10/13/pre"
+    },
+    {
+        "input": "/bus/10/send/14/lvl",
+        "output": "/busbussend/10/14/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/14/on",
+        "output": "/busbussend/10/14/mix_on"
+    },
+    {
+        "input": "/bus/10/send/14/pre",
+        "output": "/busbussend/10/14/pre"
+    },
+    {
+        "input": "/bus/10/send/15/lvl",
+        "output": "/busbussend/10/15/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/15/on",
+        "output": "/busbussend/10/15/mix_on"
+    },
+    {
+        "input": "/bus/10/send/15/pre",
+        "output": "/busbussend/10/15/pre"
+    },
+    {
+        "input": "/bus/10/send/16/lvl",
+        "output": "/busbussend/10/16/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/16/on",
+        "output": "/busbussend/10/16/mix_on"
+    },
+    {
+        "input": "/bus/10/send/16/pre",
+        "output": "/busbussend/10/16/pre"
+    },
+    {
+        "input": "/bus/10/send/2/lvl",
+        "output": "/busbussend/10/2/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/2/on",
+        "output": "/busbussend/10/2/mix_on"
+    },
+    {
+        "input": "/bus/10/send/2/pre",
+        "output": "/busbussend/10/2/pre"
+    },
+    {
+        "input": "/bus/10/send/3/lvl",
+        "output": "/busbussend/10/3/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/3/on",
+        "output": "/busbussend/10/3/mix_on"
+    },
+    {
+        "input": "/bus/10/send/3/pre",
+        "output": "/busbussend/10/3/pre"
+    },
+    {
+        "input": "/bus/10/send/4/lvl",
+        "output": "/busbussend/10/4/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/4/on",
+        "output": "/busbussend/10/4/mix_on"
+    },
+    {
+        "input": "/bus/10/send/4/pre",
+        "output": "/busbussend/10/4/pre"
+    },
+    {
+        "input": "/bus/10/send/5/lvl",
+        "output": "/busbussend/10/5/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/5/on",
+        "output": "/busbussend/10/5/mix_on"
+    },
+    {
+        "input": "/bus/10/send/5/pre",
+        "output": "/busbussend/10/5/pre"
+    },
+    {
+        "input": "/bus/10/send/6/lvl",
+        "output": "/busbussend/10/6/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/6/on",
+        "output": "/busbussend/10/6/mix_on"
+    },
+    {
+        "input": "/bus/10/send/6/pre",
+        "output": "/busbussend/10/6/pre"
+    },
+    {
+        "input": "/bus/10/send/7/lvl",
+        "output": "/busbussend/10/7/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/7/on",
+        "output": "/busbussend/10/7/mix_on"
+    },
+    {
+        "input": "/bus/10/send/7/pre",
+        "output": "/busbussend/10/7/pre"
+    },
+    {
+        "input": "/bus/10/send/8/lvl",
+        "output": "/busbussend/10/8/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/8/on",
+        "output": "/busbussend/10/8/mix_on"
+    },
+    {
+        "input": "/bus/10/send/8/pre",
+        "output": "/busbussend/10/8/pre"
+    },
+    {
+        "input": "/bus/10/send/9/lvl",
+        "output": "/busbussend/10/9/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/9/on",
+        "output": "/busbussend/10/9/mix_on"
+    },
+    {
+        "input": "/bus/10/send/9/pre",
+        "output": "/busbussend/10/9/pre"
+    },
+    {
+        "input": "/bus/10/send/MX1/lvl",
+        "output": "/bussend/10/1/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/MX1/on",
+        "output": "/bussend/10/1/mix_on"
+    },
+    {
+        "input": "/bus/10/send/MX1/pre",
+        "output": "/bussend/10/1/pre"
+    },
+    {
+        "input": "/bus/10/send/MX2/lvl",
+        "output": "/bussend/10/2/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/MX2/on",
+        "output": "/bussend/10/2/mix_on"
+    },
+    {
+        "input": "/bus/10/send/MX2/pre",
+        "output": "/bussend/10/2/pre"
+    },
+    {
+        "input": "/bus/10/send/MX3/lvl",
+        "output": "/bussend/10/3/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/MX3/on",
+        "output": "/bussend/10/3/mix_on"
+    },
+    {
+        "input": "/bus/10/send/MX3/pre",
+        "output": "/bussend/10/3/pre"
+    },
+    {
+        "input": "/bus/10/send/MX4/lvl",
+        "output": "/bussend/10/4/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/MX4/on",
+        "output": "/bussend/10/4/mix_on"
+    },
+    {
+        "input": "/bus/10/send/MX4/pre",
+        "output": "/bussend/10/4/pre"
+    },
+    {
+        "input": "/bus/10/send/MX5/lvl",
+        "output": "/bussend/10/5/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/MX5/on",
+        "output": "/bussend/10/5/mix_on"
+    },
+    {
+        "input": "/bus/10/send/MX5/pre",
+        "output": "/bussend/10/5/pre"
+    },
+    {
+        "input": "/bus/10/send/MX6/lvl",
+        "output": "/bussend/10/6/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/MX6/on",
+        "output": "/bussend/10/6/mix_on"
+    },
+    {
+        "input": "/bus/10/send/MX6/pre",
+        "output": "/bussend/10/6/pre"
+    },
+    {
+        "input": "/bus/10/send/MX7/lvl",
+        "output": "/bussend/10/7/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/MX7/on",
+        "output": "/bussend/10/7/mix_on"
+    },
+    {
+        "input": "/bus/10/send/MX7/pre",
+        "output": "/bussend/10/7/pre"
+    },
+    {
+        "input": "/bus/10/send/MX8/lvl",
+        "output": "/bussend/10/8/mix_fader"
+    },
+    {
+        "input": "/bus/10/send/MX8/on",
+        "output": "/bussend/10/8/mix_on"
+    },
+    {
+        "input": "/bus/10/send/MX8/pre",
+        "output": "/bussend/10/8/pre"
+    },
+    {
+        "input": "/bus/11/col",
+        "output": "/bus/11/config_color"
+    },
+    {
+        "input": "/bus/11/fdr",
+        "output": "/bus/11/mix_fader"
+    },
+    {
+        "input": "/bus/11/main/1/lvl",
+        "output": "/busmainsend/11/1/mix_fader"
+    },
+    {
+        "input": "/bus/11/main/1/on",
+        "output": "/busmainsend/11/1/mix_on"
+    },
+    {
+        "input": "/bus/11/main/1/pre",
+        "output": "/busmainsend/11/1/pre"
+    },
+    {
+        "input": "/bus/11/main/2/lvl",
+        "output": "/busmainsend/11/2/mix_fader"
+    },
+    {
+        "input": "/bus/11/main/2/on",
+        "output": "/busmainsend/11/2/mix_on"
+    },
+    {
+        "input": "/bus/11/main/2/pre",
+        "output": "/busmainsend/11/2/pre"
+    },
+    {
+        "input": "/bus/11/main/3/lvl",
+        "output": "/busmainsend/11/3/mix_fader"
+    },
+    {
+        "input": "/bus/11/main/3/on",
+        "output": "/busmainsend/11/3/mix_on"
+    },
+    {
+        "input": "/bus/11/main/3/pre",
+        "output": "/busmainsend/11/3/pre"
+    },
+    {
+        "input": "/bus/11/main/4/lvl",
+        "output": "/busmainsend/11/4/mix_fader"
+    },
+    {
+        "input": "/bus/11/main/4/on",
+        "output": "/busmainsend/11/4/mix_on"
+    },
+    {
+        "input": "/bus/11/main/4/pre",
+        "output": "/busmainsend/11/4/pre"
+    },
+    {
+        "input": "/bus/11/mute",
+        "output": "/bus/11/mix_on"
+    },
+    {
+        "input": "/bus/11/name",
+        "output": "/bus/11/config_name"
+    },
+    {
+        "input": "/bus/11/send/1/lvl",
+        "output": "/busbussend/11/1/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/1/on",
+        "output": "/busbussend/11/1/mix_on"
+    },
+    {
+        "input": "/bus/11/send/1/pre",
+        "output": "/busbussend/11/1/pre"
+    },
+    {
+        "input": "/bus/11/send/10/lvl",
+        "output": "/busbussend/11/10/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/10/on",
+        "output": "/busbussend/11/10/mix_on"
+    },
+    {
+        "input": "/bus/11/send/10/pre",
+        "output": "/busbussend/11/10/pre"
+    },
+    {
+        "input": "/bus/11/send/12/lvl",
+        "output": "/busbussend/11/12/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/12/on",
+        "output": "/busbussend/11/12/mix_on"
+    },
+    {
+        "input": "/bus/11/send/12/pre",
+        "output": "/busbussend/11/12/pre"
+    },
+    {
+        "input": "/bus/11/send/13/lvl",
+        "output": "/busbussend/11/13/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/13/on",
+        "output": "/busbussend/11/13/mix_on"
+    },
+    {
+        "input": "/bus/11/send/13/pre",
+        "output": "/busbussend/11/13/pre"
+    },
+    {
+        "input": "/bus/11/send/14/lvl",
+        "output": "/busbussend/11/14/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/14/on",
+        "output": "/busbussend/11/14/mix_on"
+    },
+    {
+        "input": "/bus/11/send/14/pre",
+        "output": "/busbussend/11/14/pre"
+    },
+    {
+        "input": "/bus/11/send/15/lvl",
+        "output": "/busbussend/11/15/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/15/on",
+        "output": "/busbussend/11/15/mix_on"
+    },
+    {
+        "input": "/bus/11/send/15/pre",
+        "output": "/busbussend/11/15/pre"
+    },
+    {
+        "input": "/bus/11/send/16/lvl",
+        "output": "/busbussend/11/16/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/16/on",
+        "output": "/busbussend/11/16/mix_on"
+    },
+    {
+        "input": "/bus/11/send/16/pre",
+        "output": "/busbussend/11/16/pre"
+    },
+    {
+        "input": "/bus/11/send/2/lvl",
+        "output": "/busbussend/11/2/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/2/on",
+        "output": "/busbussend/11/2/mix_on"
+    },
+    {
+        "input": "/bus/11/send/2/pre",
+        "output": "/busbussend/11/2/pre"
+    },
+    {
+        "input": "/bus/11/send/3/lvl",
+        "output": "/busbussend/11/3/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/3/on",
+        "output": "/busbussend/11/3/mix_on"
+    },
+    {
+        "input": "/bus/11/send/3/pre",
+        "output": "/busbussend/11/3/pre"
+    },
+    {
+        "input": "/bus/11/send/4/lvl",
+        "output": "/busbussend/11/4/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/4/on",
+        "output": "/busbussend/11/4/mix_on"
+    },
+    {
+        "input": "/bus/11/send/4/pre",
+        "output": "/busbussend/11/4/pre"
+    },
+    {
+        "input": "/bus/11/send/5/lvl",
+        "output": "/busbussend/11/5/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/5/on",
+        "output": "/busbussend/11/5/mix_on"
+    },
+    {
+        "input": "/bus/11/send/5/pre",
+        "output": "/busbussend/11/5/pre"
+    },
+    {
+        "input": "/bus/11/send/6/lvl",
+        "output": "/busbussend/11/6/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/6/on",
+        "output": "/busbussend/11/6/mix_on"
+    },
+    {
+        "input": "/bus/11/send/6/pre",
+        "output": "/busbussend/11/6/pre"
+    },
+    {
+        "input": "/bus/11/send/7/lvl",
+        "output": "/busbussend/11/7/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/7/on",
+        "output": "/busbussend/11/7/mix_on"
+    },
+    {
+        "input": "/bus/11/send/7/pre",
+        "output": "/busbussend/11/7/pre"
+    },
+    {
+        "input": "/bus/11/send/8/lvl",
+        "output": "/busbussend/11/8/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/8/on",
+        "output": "/busbussend/11/8/mix_on"
+    },
+    {
+        "input": "/bus/11/send/8/pre",
+        "output": "/busbussend/11/8/pre"
+    },
+    {
+        "input": "/bus/11/send/9/lvl",
+        "output": "/busbussend/11/9/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/9/on",
+        "output": "/busbussend/11/9/mix_on"
+    },
+    {
+        "input": "/bus/11/send/9/pre",
+        "output": "/busbussend/11/9/pre"
+    },
+    {
+        "input": "/bus/11/send/MX1/lvl",
+        "output": "/bussend/11/1/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/MX1/on",
+        "output": "/bussend/11/1/mix_on"
+    },
+    {
+        "input": "/bus/11/send/MX1/pre",
+        "output": "/bussend/11/1/pre"
+    },
+    {
+        "input": "/bus/11/send/MX2/lvl",
+        "output": "/bussend/11/2/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/MX2/on",
+        "output": "/bussend/11/2/mix_on"
+    },
+    {
+        "input": "/bus/11/send/MX2/pre",
+        "output": "/bussend/11/2/pre"
+    },
+    {
+        "input": "/bus/11/send/MX3/lvl",
+        "output": "/bussend/11/3/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/MX3/on",
+        "output": "/bussend/11/3/mix_on"
+    },
+    {
+        "input": "/bus/11/send/MX3/pre",
+        "output": "/bussend/11/3/pre"
+    },
+    {
+        "input": "/bus/11/send/MX4/lvl",
+        "output": "/bussend/11/4/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/MX4/on",
+        "output": "/bussend/11/4/mix_on"
+    },
+    {
+        "input": "/bus/11/send/MX4/pre",
+        "output": "/bussend/11/4/pre"
+    },
+    {
+        "input": "/bus/11/send/MX5/lvl",
+        "output": "/bussend/11/5/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/MX5/on",
+        "output": "/bussend/11/5/mix_on"
+    },
+    {
+        "input": "/bus/11/send/MX5/pre",
+        "output": "/bussend/11/5/pre"
+    },
+    {
+        "input": "/bus/11/send/MX6/lvl",
+        "output": "/bussend/11/6/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/MX6/on",
+        "output": "/bussend/11/6/mix_on"
+    },
+    {
+        "input": "/bus/11/send/MX6/pre",
+        "output": "/bussend/11/6/pre"
+    },
+    {
+        "input": "/bus/11/send/MX7/lvl",
+        "output": "/bussend/11/7/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/MX7/on",
+        "output": "/bussend/11/7/mix_on"
+    },
+    {
+        "input": "/bus/11/send/MX7/pre",
+        "output": "/bussend/11/7/pre"
+    },
+    {
+        "input": "/bus/11/send/MX8/lvl",
+        "output": "/bussend/11/8/mix_fader"
+    },
+    {
+        "input": "/bus/11/send/MX8/on",
+        "output": "/bussend/11/8/mix_on"
+    },
+    {
+        "input": "/bus/11/send/MX8/pre",
+        "output": "/bussend/11/8/pre"
+    },
+    {
+        "input": "/bus/12/col",
+        "output": "/bus/12/config_color"
+    },
+    {
+        "input": "/bus/12/fdr",
+        "output": "/bus/12/mix_fader"
+    },
+    {
+        "input": "/bus/12/main/1/lvl",
+        "output": "/busmainsend/12/1/mix_fader"
+    },
+    {
+        "input": "/bus/12/main/1/on",
+        "output": "/busmainsend/12/1/mix_on"
+    },
+    {
+        "input": "/bus/12/main/1/pre",
+        "output": "/busmainsend/12/1/pre"
+    },
+    {
+        "input": "/bus/12/main/2/lvl",
+        "output": "/busmainsend/12/2/mix_fader"
+    },
+    {
+        "input": "/bus/12/main/2/on",
+        "output": "/busmainsend/12/2/mix_on"
+    },
+    {
+        "input": "/bus/12/main/2/pre",
+        "output": "/busmainsend/12/2/pre"
+    },
+    {
+        "input": "/bus/12/main/3/lvl",
+        "output": "/busmainsend/12/3/mix_fader"
+    },
+    {
+        "input": "/bus/12/main/3/on",
+        "output": "/busmainsend/12/3/mix_on"
+    },
+    {
+        "input": "/bus/12/main/3/pre",
+        "output": "/busmainsend/12/3/pre"
+    },
+    {
+        "input": "/bus/12/main/4/lvl",
+        "output": "/busmainsend/12/4/mix_fader"
+    },
+    {
+        "input": "/bus/12/main/4/on",
+        "output": "/busmainsend/12/4/mix_on"
+    },
+    {
+        "input": "/bus/12/main/4/pre",
+        "output": "/busmainsend/12/4/pre"
+    },
+    {
+        "input": "/bus/12/mute",
+        "output": "/bus/12/mix_on"
+    },
+    {
+        "input": "/bus/12/name",
+        "output": "/bus/12/config_name"
+    },
+    {
+        "input": "/bus/12/send/1/lvl",
+        "output": "/busbussend/12/1/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/1/on",
+        "output": "/busbussend/12/1/mix_on"
+    },
+    {
+        "input": "/bus/12/send/1/pre",
+        "output": "/busbussend/12/1/pre"
+    },
+    {
+        "input": "/bus/12/send/10/lvl",
+        "output": "/busbussend/12/10/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/10/on",
+        "output": "/busbussend/12/10/mix_on"
+    },
+    {
+        "input": "/bus/12/send/10/pre",
+        "output": "/busbussend/12/10/pre"
+    },
+    {
+        "input": "/bus/12/send/11/lvl",
+        "output": "/busbussend/12/11/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/11/on",
+        "output": "/busbussend/12/11/mix_on"
+    },
+    {
+        "input": "/bus/12/send/11/pre",
+        "output": "/busbussend/12/11/pre"
+    },
+    {
+        "input": "/bus/12/send/13/lvl",
+        "output": "/busbussend/12/13/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/13/on",
+        "output": "/busbussend/12/13/mix_on"
+    },
+    {
+        "input": "/bus/12/send/13/pre",
+        "output": "/busbussend/12/13/pre"
+    },
+    {
+        "input": "/bus/12/send/14/lvl",
+        "output": "/busbussend/12/14/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/14/on",
+        "output": "/busbussend/12/14/mix_on"
+    },
+    {
+        "input": "/bus/12/send/14/pre",
+        "output": "/busbussend/12/14/pre"
+    },
+    {
+        "input": "/bus/12/send/15/lvl",
+        "output": "/busbussend/12/15/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/15/on",
+        "output": "/busbussend/12/15/mix_on"
+    },
+    {
+        "input": "/bus/12/send/15/pre",
+        "output": "/busbussend/12/15/pre"
+    },
+    {
+        "input": "/bus/12/send/16/lvl",
+        "output": "/busbussend/12/16/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/16/on",
+        "output": "/busbussend/12/16/mix_on"
+    },
+    {
+        "input": "/bus/12/send/16/pre",
+        "output": "/busbussend/12/16/pre"
+    },
+    {
+        "input": "/bus/12/send/2/lvl",
+        "output": "/busbussend/12/2/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/2/on",
+        "output": "/busbussend/12/2/mix_on"
+    },
+    {
+        "input": "/bus/12/send/2/pre",
+        "output": "/busbussend/12/2/pre"
+    },
+    {
+        "input": "/bus/12/send/3/lvl",
+        "output": "/busbussend/12/3/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/3/on",
+        "output": "/busbussend/12/3/mix_on"
+    },
+    {
+        "input": "/bus/12/send/3/pre",
+        "output": "/busbussend/12/3/pre"
+    },
+    {
+        "input": "/bus/12/send/4/lvl",
+        "output": "/busbussend/12/4/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/4/on",
+        "output": "/busbussend/12/4/mix_on"
+    },
+    {
+        "input": "/bus/12/send/4/pre",
+        "output": "/busbussend/12/4/pre"
+    },
+    {
+        "input": "/bus/12/send/5/lvl",
+        "output": "/busbussend/12/5/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/5/on",
+        "output": "/busbussend/12/5/mix_on"
+    },
+    {
+        "input": "/bus/12/send/5/pre",
+        "output": "/busbussend/12/5/pre"
+    },
+    {
+        "input": "/bus/12/send/6/lvl",
+        "output": "/busbussend/12/6/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/6/on",
+        "output": "/busbussend/12/6/mix_on"
+    },
+    {
+        "input": "/bus/12/send/6/pre",
+        "output": "/busbussend/12/6/pre"
+    },
+    {
+        "input": "/bus/12/send/7/lvl",
+        "output": "/busbussend/12/7/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/7/on",
+        "output": "/busbussend/12/7/mix_on"
+    },
+    {
+        "input": "/bus/12/send/7/pre",
+        "output": "/busbussend/12/7/pre"
+    },
+    {
+        "input": "/bus/12/send/8/lvl",
+        "output": "/busbussend/12/8/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/8/on",
+        "output": "/busbussend/12/8/mix_on"
+    },
+    {
+        "input": "/bus/12/send/8/pre",
+        "output": "/busbussend/12/8/pre"
+    },
+    {
+        "input": "/bus/12/send/9/lvl",
+        "output": "/busbussend/12/9/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/9/on",
+        "output": "/busbussend/12/9/mix_on"
+    },
+    {
+        "input": "/bus/12/send/9/pre",
+        "output": "/busbussend/12/9/pre"
+    },
+    {
+        "input": "/bus/12/send/MX1/lvl",
+        "output": "/bussend/12/1/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/MX1/on",
+        "output": "/bussend/12/1/mix_on"
+    },
+    {
+        "input": "/bus/12/send/MX1/pre",
+        "output": "/bussend/12/1/pre"
+    },
+    {
+        "input": "/bus/12/send/MX2/lvl",
+        "output": "/bussend/12/2/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/MX2/on",
+        "output": "/bussend/12/2/mix_on"
+    },
+    {
+        "input": "/bus/12/send/MX2/pre",
+        "output": "/bussend/12/2/pre"
+    },
+    {
+        "input": "/bus/12/send/MX3/lvl",
+        "output": "/bussend/12/3/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/MX3/on",
+        "output": "/bussend/12/3/mix_on"
+    },
+    {
+        "input": "/bus/12/send/MX3/pre",
+        "output": "/bussend/12/3/pre"
+    },
+    {
+        "input": "/bus/12/send/MX4/lvl",
+        "output": "/bussend/12/4/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/MX4/on",
+        "output": "/bussend/12/4/mix_on"
+    },
+    {
+        "input": "/bus/12/send/MX4/pre",
+        "output": "/bussend/12/4/pre"
+    },
+    {
+        "input": "/bus/12/send/MX5/lvl",
+        "output": "/bussend/12/5/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/MX5/on",
+        "output": "/bussend/12/5/mix_on"
+    },
+    {
+        "input": "/bus/12/send/MX5/pre",
+        "output": "/bussend/12/5/pre"
+    },
+    {
+        "input": "/bus/12/send/MX6/lvl",
+        "output": "/bussend/12/6/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/MX6/on",
+        "output": "/bussend/12/6/mix_on"
+    },
+    {
+        "input": "/bus/12/send/MX6/pre",
+        "output": "/bussend/12/6/pre"
+    },
+    {
+        "input": "/bus/12/send/MX7/lvl",
+        "output": "/bussend/12/7/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/MX7/on",
+        "output": "/bussend/12/7/mix_on"
+    },
+    {
+        "input": "/bus/12/send/MX7/pre",
+        "output": "/bussend/12/7/pre"
+    },
+    {
+        "input": "/bus/12/send/MX8/lvl",
+        "output": "/bussend/12/8/mix_fader"
+    },
+    {
+        "input": "/bus/12/send/MX8/on",
+        "output": "/bussend/12/8/mix_on"
+    },
+    {
+        "input": "/bus/12/send/MX8/pre",
+        "output": "/bussend/12/8/pre"
+    },
+    {
+        "input": "/bus/13/col",
+        "output": "/bus/13/config_color"
+    },
+    {
+        "input": "/bus/13/fdr",
+        "output": "/bus/13/mix_fader"
+    },
+    {
+        "input": "/bus/13/main/1/lvl",
+        "output": "/busmainsend/13/1/mix_fader"
+    },
+    {
+        "input": "/bus/13/main/1/on",
+        "output": "/busmainsend/13/1/mix_on"
+    },
+    {
+        "input": "/bus/13/main/1/pre",
+        "output": "/busmainsend/13/1/pre"
+    },
+    {
+        "input": "/bus/13/main/2/lvl",
+        "output": "/busmainsend/13/2/mix_fader"
+    },
+    {
+        "input": "/bus/13/main/2/on",
+        "output": "/busmainsend/13/2/mix_on"
+    },
+    {
+        "input": "/bus/13/main/2/pre",
+        "output": "/busmainsend/13/2/pre"
+    },
+    {
+        "input": "/bus/13/main/3/lvl",
+        "output": "/busmainsend/13/3/mix_fader"
+    },
+    {
+        "input": "/bus/13/main/3/on",
+        "output": "/busmainsend/13/3/mix_on"
+    },
+    {
+        "input": "/bus/13/main/3/pre",
+        "output": "/busmainsend/13/3/pre"
+    },
+    {
+        "input": "/bus/13/main/4/lvl",
+        "output": "/busmainsend/13/4/mix_fader"
+    },
+    {
+        "input": "/bus/13/main/4/on",
+        "output": "/busmainsend/13/4/mix_on"
+    },
+    {
+        "input": "/bus/13/main/4/pre",
+        "output": "/busmainsend/13/4/pre"
+    },
+    {
+        "input": "/bus/13/mute",
+        "output": "/bus/13/mix_on"
+    },
+    {
+        "input": "/bus/13/name",
+        "output": "/bus/13/config_name"
+    },
+    {
+        "input": "/bus/13/send/1/lvl",
+        "output": "/busbussend/13/1/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/1/on",
+        "output": "/busbussend/13/1/mix_on"
+    },
+    {
+        "input": "/bus/13/send/1/pre",
+        "output": "/busbussend/13/1/pre"
+    },
+    {
+        "input": "/bus/13/send/10/lvl",
+        "output": "/busbussend/13/10/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/10/on",
+        "output": "/busbussend/13/10/mix_on"
+    },
+    {
+        "input": "/bus/13/send/10/pre",
+        "output": "/busbussend/13/10/pre"
+    },
+    {
+        "input": "/bus/13/send/11/lvl",
+        "output": "/busbussend/13/11/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/11/on",
+        "output": "/busbussend/13/11/mix_on"
+    },
+    {
+        "input": "/bus/13/send/11/pre",
+        "output": "/busbussend/13/11/pre"
+    },
+    {
+        "input": "/bus/13/send/12/lvl",
+        "output": "/busbussend/13/12/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/12/on",
+        "output": "/busbussend/13/12/mix_on"
+    },
+    {
+        "input": "/bus/13/send/12/pre",
+        "output": "/busbussend/13/12/pre"
+    },
+    {
+        "input": "/bus/13/send/14/lvl",
+        "output": "/busbussend/13/14/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/14/on",
+        "output": "/busbussend/13/14/mix_on"
+    },
+    {
+        "input": "/bus/13/send/14/pre",
+        "output": "/busbussend/13/14/pre"
+    },
+    {
+        "input": "/bus/13/send/15/lvl",
+        "output": "/busbussend/13/15/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/15/on",
+        "output": "/busbussend/13/15/mix_on"
+    },
+    {
+        "input": "/bus/13/send/15/pre",
+        "output": "/busbussend/13/15/pre"
+    },
+    {
+        "input": "/bus/13/send/16/lvl",
+        "output": "/busbussend/13/16/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/16/on",
+        "output": "/busbussend/13/16/mix_on"
+    },
+    {
+        "input": "/bus/13/send/16/pre",
+        "output": "/busbussend/13/16/pre"
+    },
+    {
+        "input": "/bus/13/send/2/lvl",
+        "output": "/busbussend/13/2/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/2/on",
+        "output": "/busbussend/13/2/mix_on"
+    },
+    {
+        "input": "/bus/13/send/2/pre",
+        "output": "/busbussend/13/2/pre"
+    },
+    {
+        "input": "/bus/13/send/3/lvl",
+        "output": "/busbussend/13/3/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/3/on",
+        "output": "/busbussend/13/3/mix_on"
+    },
+    {
+        "input": "/bus/13/send/3/pre",
+        "output": "/busbussend/13/3/pre"
+    },
+    {
+        "input": "/bus/13/send/4/lvl",
+        "output": "/busbussend/13/4/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/4/on",
+        "output": "/busbussend/13/4/mix_on"
+    },
+    {
+        "input": "/bus/13/send/4/pre",
+        "output": "/busbussend/13/4/pre"
+    },
+    {
+        "input": "/bus/13/send/5/lvl",
+        "output": "/busbussend/13/5/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/5/on",
+        "output": "/busbussend/13/5/mix_on"
+    },
+    {
+        "input": "/bus/13/send/5/pre",
+        "output": "/busbussend/13/5/pre"
+    },
+    {
+        "input": "/bus/13/send/6/lvl",
+        "output": "/busbussend/13/6/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/6/on",
+        "output": "/busbussend/13/6/mix_on"
+    },
+    {
+        "input": "/bus/13/send/6/pre",
+        "output": "/busbussend/13/6/pre"
+    },
+    {
+        "input": "/bus/13/send/7/lvl",
+        "output": "/busbussend/13/7/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/7/on",
+        "output": "/busbussend/13/7/mix_on"
+    },
+    {
+        "input": "/bus/13/send/7/pre",
+        "output": "/busbussend/13/7/pre"
+    },
+    {
+        "input": "/bus/13/send/8/lvl",
+        "output": "/busbussend/13/8/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/8/on",
+        "output": "/busbussend/13/8/mix_on"
+    },
+    {
+        "input": "/bus/13/send/8/pre",
+        "output": "/busbussend/13/8/pre"
+    },
+    {
+        "input": "/bus/13/send/9/lvl",
+        "output": "/busbussend/13/9/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/9/on",
+        "output": "/busbussend/13/9/mix_on"
+    },
+    {
+        "input": "/bus/13/send/9/pre",
+        "output": "/busbussend/13/9/pre"
+    },
+    {
+        "input": "/bus/13/send/MX1/lvl",
+        "output": "/bussend/13/1/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/MX1/on",
+        "output": "/bussend/13/1/mix_on"
+    },
+    {
+        "input": "/bus/13/send/MX1/pre",
+        "output": "/bussend/13/1/pre"
+    },
+    {
+        "input": "/bus/13/send/MX2/lvl",
+        "output": "/bussend/13/2/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/MX2/on",
+        "output": "/bussend/13/2/mix_on"
+    },
+    {
+        "input": "/bus/13/send/MX2/pre",
+        "output": "/bussend/13/2/pre"
+    },
+    {
+        "input": "/bus/13/send/MX3/lvl",
+        "output": "/bussend/13/3/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/MX3/on",
+        "output": "/bussend/13/3/mix_on"
+    },
+    {
+        "input": "/bus/13/send/MX3/pre",
+        "output": "/bussend/13/3/pre"
+    },
+    {
+        "input": "/bus/13/send/MX4/lvl",
+        "output": "/bussend/13/4/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/MX4/on",
+        "output": "/bussend/13/4/mix_on"
+    },
+    {
+        "input": "/bus/13/send/MX4/pre",
+        "output": "/bussend/13/4/pre"
+    },
+    {
+        "input": "/bus/13/send/MX5/lvl",
+        "output": "/bussend/13/5/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/MX5/on",
+        "output": "/bussend/13/5/mix_on"
+    },
+    {
+        "input": "/bus/13/send/MX5/pre",
+        "output": "/bussend/13/5/pre"
+    },
+    {
+        "input": "/bus/13/send/MX6/lvl",
+        "output": "/bussend/13/6/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/MX6/on",
+        "output": "/bussend/13/6/mix_on"
+    },
+    {
+        "input": "/bus/13/send/MX6/pre",
+        "output": "/bussend/13/6/pre"
+    },
+    {
+        "input": "/bus/13/send/MX7/lvl",
+        "output": "/bussend/13/7/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/MX7/on",
+        "output": "/bussend/13/7/mix_on"
+    },
+    {
+        "input": "/bus/13/send/MX7/pre",
+        "output": "/bussend/13/7/pre"
+    },
+    {
+        "input": "/bus/13/send/MX8/lvl",
+        "output": "/bussend/13/8/mix_fader"
+    },
+    {
+        "input": "/bus/13/send/MX8/on",
+        "output": "/bussend/13/8/mix_on"
+    },
+    {
+        "input": "/bus/13/send/MX8/pre",
+        "output": "/bussend/13/8/pre"
+    },
+    {
+        "input": "/bus/14/col",
+        "output": "/bus/14/config_color"
+    },
+    {
+        "input": "/bus/14/fdr",
+        "output": "/bus/14/mix_fader"
+    },
+    {
+        "input": "/bus/14/main/1/lvl",
+        "output": "/busmainsend/14/1/mix_fader"
+    },
+    {
+        "input": "/bus/14/main/1/on",
+        "output": "/busmainsend/14/1/mix_on"
+    },
+    {
+        "input": "/bus/14/main/1/pre",
+        "output": "/busmainsend/14/1/pre"
+    },
+    {
+        "input": "/bus/14/main/2/lvl",
+        "output": "/busmainsend/14/2/mix_fader"
+    },
+    {
+        "input": "/bus/14/main/2/on",
+        "output": "/busmainsend/14/2/mix_on"
+    },
+    {
+        "input": "/bus/14/main/2/pre",
+        "output": "/busmainsend/14/2/pre"
+    },
+    {
+        "input": "/bus/14/main/3/lvl",
+        "output": "/busmainsend/14/3/mix_fader"
+    },
+    {
+        "input": "/bus/14/main/3/on",
+        "output": "/busmainsend/14/3/mix_on"
+    },
+    {
+        "input": "/bus/14/main/3/pre",
+        "output": "/busmainsend/14/3/pre"
+    },
+    {
+        "input": "/bus/14/main/4/lvl",
+        "output": "/busmainsend/14/4/mix_fader"
+    },
+    {
+        "input": "/bus/14/main/4/on",
+        "output": "/busmainsend/14/4/mix_on"
+    },
+    {
+        "input": "/bus/14/main/4/pre",
+        "output": "/busmainsend/14/4/pre"
+    },
+    {
+        "input": "/bus/14/mute",
+        "output": "/bus/14/mix_on"
+    },
+    {
+        "input": "/bus/14/name",
+        "output": "/bus/14/config_name"
+    },
+    {
+        "input": "/bus/14/send/1/lvl",
+        "output": "/busbussend/14/1/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/1/on",
+        "output": "/busbussend/14/1/mix_on"
+    },
+    {
+        "input": "/bus/14/send/1/pre",
+        "output": "/busbussend/14/1/pre"
+    },
+    {
+        "input": "/bus/14/send/10/lvl",
+        "output": "/busbussend/14/10/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/10/on",
+        "output": "/busbussend/14/10/mix_on"
+    },
+    {
+        "input": "/bus/14/send/10/pre",
+        "output": "/busbussend/14/10/pre"
+    },
+    {
+        "input": "/bus/14/send/11/lvl",
+        "output": "/busbussend/14/11/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/11/on",
+        "output": "/busbussend/14/11/mix_on"
+    },
+    {
+        "input": "/bus/14/send/11/pre",
+        "output": "/busbussend/14/11/pre"
+    },
+    {
+        "input": "/bus/14/send/12/lvl",
+        "output": "/busbussend/14/12/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/12/on",
+        "output": "/busbussend/14/12/mix_on"
+    },
+    {
+        "input": "/bus/14/send/12/pre",
+        "output": "/busbussend/14/12/pre"
+    },
+    {
+        "input": "/bus/14/send/13/lvl",
+        "output": "/busbussend/14/13/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/13/on",
+        "output": "/busbussend/14/13/mix_on"
+    },
+    {
+        "input": "/bus/14/send/13/pre",
+        "output": "/busbussend/14/13/pre"
+    },
+    {
+        "input": "/bus/14/send/15/lvl",
+        "output": "/busbussend/14/15/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/15/on",
+        "output": "/busbussend/14/15/mix_on"
+    },
+    {
+        "input": "/bus/14/send/15/pre",
+        "output": "/busbussend/14/15/pre"
+    },
+    {
+        "input": "/bus/14/send/16/lvl",
+        "output": "/busbussend/14/16/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/16/on",
+        "output": "/busbussend/14/16/mix_on"
+    },
+    {
+        "input": "/bus/14/send/16/pre",
+        "output": "/busbussend/14/16/pre"
+    },
+    {
+        "input": "/bus/14/send/2/lvl",
+        "output": "/busbussend/14/2/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/2/on",
+        "output": "/busbussend/14/2/mix_on"
+    },
+    {
+        "input": "/bus/14/send/2/pre",
+        "output": "/busbussend/14/2/pre"
+    },
+    {
+        "input": "/bus/14/send/3/lvl",
+        "output": "/busbussend/14/3/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/3/on",
+        "output": "/busbussend/14/3/mix_on"
+    },
+    {
+        "input": "/bus/14/send/3/pre",
+        "output": "/busbussend/14/3/pre"
+    },
+    {
+        "input": "/bus/14/send/4/lvl",
+        "output": "/busbussend/14/4/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/4/on",
+        "output": "/busbussend/14/4/mix_on"
+    },
+    {
+        "input": "/bus/14/send/4/pre",
+        "output": "/busbussend/14/4/pre"
+    },
+    {
+        "input": "/bus/14/send/5/lvl",
+        "output": "/busbussend/14/5/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/5/on",
+        "output": "/busbussend/14/5/mix_on"
+    },
+    {
+        "input": "/bus/14/send/5/pre",
+        "output": "/busbussend/14/5/pre"
+    },
+    {
+        "input": "/bus/14/send/6/lvl",
+        "output": "/busbussend/14/6/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/6/on",
+        "output": "/busbussend/14/6/mix_on"
+    },
+    {
+        "input": "/bus/14/send/6/pre",
+        "output": "/busbussend/14/6/pre"
+    },
+    {
+        "input": "/bus/14/send/7/lvl",
+        "output": "/busbussend/14/7/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/7/on",
+        "output": "/busbussend/14/7/mix_on"
+    },
+    {
+        "input": "/bus/14/send/7/pre",
+        "output": "/busbussend/14/7/pre"
+    },
+    {
+        "input": "/bus/14/send/8/lvl",
+        "output": "/busbussend/14/8/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/8/on",
+        "output": "/busbussend/14/8/mix_on"
+    },
+    {
+        "input": "/bus/14/send/8/pre",
+        "output": "/busbussend/14/8/pre"
+    },
+    {
+        "input": "/bus/14/send/9/lvl",
+        "output": "/busbussend/14/9/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/9/on",
+        "output": "/busbussend/14/9/mix_on"
+    },
+    {
+        "input": "/bus/14/send/9/pre",
+        "output": "/busbussend/14/9/pre"
+    },
+    {
+        "input": "/bus/14/send/MX1/lvl",
+        "output": "/bussend/14/1/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/MX1/on",
+        "output": "/bussend/14/1/mix_on"
+    },
+    {
+        "input": "/bus/14/send/MX1/pre",
+        "output": "/bussend/14/1/pre"
+    },
+    {
+        "input": "/bus/14/send/MX2/lvl",
+        "output": "/bussend/14/2/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/MX2/on",
+        "output": "/bussend/14/2/mix_on"
+    },
+    {
+        "input": "/bus/14/send/MX2/pre",
+        "output": "/bussend/14/2/pre"
+    },
+    {
+        "input": "/bus/14/send/MX3/lvl",
+        "output": "/bussend/14/3/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/MX3/on",
+        "output": "/bussend/14/3/mix_on"
+    },
+    {
+        "input": "/bus/14/send/MX3/pre",
+        "output": "/bussend/14/3/pre"
+    },
+    {
+        "input": "/bus/14/send/MX4/lvl",
+        "output": "/bussend/14/4/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/MX4/on",
+        "output": "/bussend/14/4/mix_on"
+    },
+    {
+        "input": "/bus/14/send/MX4/pre",
+        "output": "/bussend/14/4/pre"
+    },
+    {
+        "input": "/bus/14/send/MX5/lvl",
+        "output": "/bussend/14/5/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/MX5/on",
+        "output": "/bussend/14/5/mix_on"
+    },
+    {
+        "input": "/bus/14/send/MX5/pre",
+        "output": "/bussend/14/5/pre"
+    },
+    {
+        "input": "/bus/14/send/MX6/lvl",
+        "output": "/bussend/14/6/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/MX6/on",
+        "output": "/bussend/14/6/mix_on"
+    },
+    {
+        "input": "/bus/14/send/MX6/pre",
+        "output": "/bussend/14/6/pre"
+    },
+    {
+        "input": "/bus/14/send/MX7/lvl",
+        "output": "/bussend/14/7/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/MX7/on",
+        "output": "/bussend/14/7/mix_on"
+    },
+    {
+        "input": "/bus/14/send/MX7/pre",
+        "output": "/bussend/14/7/pre"
+    },
+    {
+        "input": "/bus/14/send/MX8/lvl",
+        "output": "/bussend/14/8/mix_fader"
+    },
+    {
+        "input": "/bus/14/send/MX8/on",
+        "output": "/bussend/14/8/mix_on"
+    },
+    {
+        "input": "/bus/14/send/MX8/pre",
+        "output": "/bussend/14/8/pre"
+    },
+    {
+        "input": "/bus/15/col",
+        "output": "/bus/15/config_color"
+    },
+    {
+        "input": "/bus/15/fdr",
+        "output": "/bus/15/mix_fader"
+    },
+    {
+        "input": "/bus/15/main/1/lvl",
+        "output": "/busmainsend/15/1/mix_fader"
+    },
+    {
+        "input": "/bus/15/main/1/on",
+        "output": "/busmainsend/15/1/mix_on"
+    },
+    {
+        "input": "/bus/15/main/1/pre",
+        "output": "/busmainsend/15/1/pre"
+    },
+    {
+        "input": "/bus/15/main/2/lvl",
+        "output": "/busmainsend/15/2/mix_fader"
+    },
+    {
+        "input": "/bus/15/main/2/on",
+        "output": "/busmainsend/15/2/mix_on"
+    },
+    {
+        "input": "/bus/15/main/2/pre",
+        "output": "/busmainsend/15/2/pre"
+    },
+    {
+        "input": "/bus/15/main/3/lvl",
+        "output": "/busmainsend/15/3/mix_fader"
+    },
+    {
+        "input": "/bus/15/main/3/on",
+        "output": "/busmainsend/15/3/mix_on"
+    },
+    {
+        "input": "/bus/15/main/3/pre",
+        "output": "/busmainsend/15/3/pre"
+    },
+    {
+        "input": "/bus/15/main/4/lvl",
+        "output": "/busmainsend/15/4/mix_fader"
+    },
+    {
+        "input": "/bus/15/main/4/on",
+        "output": "/busmainsend/15/4/mix_on"
+    },
+    {
+        "input": "/bus/15/main/4/pre",
+        "output": "/busmainsend/15/4/pre"
+    },
+    {
+        "input": "/bus/15/mute",
+        "output": "/bus/15/mix_on"
+    },
+    {
+        "input": "/bus/15/name",
+        "output": "/bus/15/config_name"
+    },
+    {
+        "input": "/bus/15/send/1/lvl",
+        "output": "/busbussend/15/1/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/1/on",
+        "output": "/busbussend/15/1/mix_on"
+    },
+    {
+        "input": "/bus/15/send/1/pre",
+        "output": "/busbussend/15/1/pre"
+    },
+    {
+        "input": "/bus/15/send/10/lvl",
+        "output": "/busbussend/15/10/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/10/on",
+        "output": "/busbussend/15/10/mix_on"
+    },
+    {
+        "input": "/bus/15/send/10/pre",
+        "output": "/busbussend/15/10/pre"
+    },
+    {
+        "input": "/bus/15/send/11/lvl",
+        "output": "/busbussend/15/11/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/11/on",
+        "output": "/busbussend/15/11/mix_on"
+    },
+    {
+        "input": "/bus/15/send/11/pre",
+        "output": "/busbussend/15/11/pre"
+    },
+    {
+        "input": "/bus/15/send/12/lvl",
+        "output": "/busbussend/15/12/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/12/on",
+        "output": "/busbussend/15/12/mix_on"
+    },
+    {
+        "input": "/bus/15/send/12/pre",
+        "output": "/busbussend/15/12/pre"
+    },
+    {
+        "input": "/bus/15/send/13/lvl",
+        "output": "/busbussend/15/13/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/13/on",
+        "output": "/busbussend/15/13/mix_on"
+    },
+    {
+        "input": "/bus/15/send/13/pre",
+        "output": "/busbussend/15/13/pre"
+    },
+    {
+        "input": "/bus/15/send/14/lvl",
+        "output": "/busbussend/15/14/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/14/on",
+        "output": "/busbussend/15/14/mix_on"
+    },
+    {
+        "input": "/bus/15/send/14/pre",
+        "output": "/busbussend/15/14/pre"
+    },
+    {
+        "input": "/bus/15/send/16/lvl",
+        "output": "/busbussend/15/16/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/16/on",
+        "output": "/busbussend/15/16/mix_on"
+    },
+    {
+        "input": "/bus/15/send/16/pre",
+        "output": "/busbussend/15/16/pre"
+    },
+    {
+        "input": "/bus/15/send/2/lvl",
+        "output": "/busbussend/15/2/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/2/on",
+        "output": "/busbussend/15/2/mix_on"
+    },
+    {
+        "input": "/bus/15/send/2/pre",
+        "output": "/busbussend/15/2/pre"
+    },
+    {
+        "input": "/bus/15/send/3/lvl",
+        "output": "/busbussend/15/3/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/3/on",
+        "output": "/busbussend/15/3/mix_on"
+    },
+    {
+        "input": "/bus/15/send/3/pre",
+        "output": "/busbussend/15/3/pre"
+    },
+    {
+        "input": "/bus/15/send/4/lvl",
+        "output": "/busbussend/15/4/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/4/on",
+        "output": "/busbussend/15/4/mix_on"
+    },
+    {
+        "input": "/bus/15/send/4/pre",
+        "output": "/busbussend/15/4/pre"
+    },
+    {
+        "input": "/bus/15/send/5/lvl",
+        "output": "/busbussend/15/5/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/5/on",
+        "output": "/busbussend/15/5/mix_on"
+    },
+    {
+        "input": "/bus/15/send/5/pre",
+        "output": "/busbussend/15/5/pre"
+    },
+    {
+        "input": "/bus/15/send/6/lvl",
+        "output": "/busbussend/15/6/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/6/on",
+        "output": "/busbussend/15/6/mix_on"
+    },
+    {
+        "input": "/bus/15/send/6/pre",
+        "output": "/busbussend/15/6/pre"
+    },
+    {
+        "input": "/bus/15/send/7/lvl",
+        "output": "/busbussend/15/7/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/7/on",
+        "output": "/busbussend/15/7/mix_on"
+    },
+    {
+        "input": "/bus/15/send/7/pre",
+        "output": "/busbussend/15/7/pre"
+    },
+    {
+        "input": "/bus/15/send/8/lvl",
+        "output": "/busbussend/15/8/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/8/on",
+        "output": "/busbussend/15/8/mix_on"
+    },
+    {
+        "input": "/bus/15/send/8/pre",
+        "output": "/busbussend/15/8/pre"
+    },
+    {
+        "input": "/bus/15/send/9/lvl",
+        "output": "/busbussend/15/9/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/9/on",
+        "output": "/busbussend/15/9/mix_on"
+    },
+    {
+        "input": "/bus/15/send/9/pre",
+        "output": "/busbussend/15/9/pre"
+    },
+    {
+        "input": "/bus/15/send/MX1/lvl",
+        "output": "/bussend/15/1/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/MX1/on",
+        "output": "/bussend/15/1/mix_on"
+    },
+    {
+        "input": "/bus/15/send/MX1/pre",
+        "output": "/bussend/15/1/pre"
+    },
+    {
+        "input": "/bus/15/send/MX2/lvl",
+        "output": "/bussend/15/2/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/MX2/on",
+        "output": "/bussend/15/2/mix_on"
+    },
+    {
+        "input": "/bus/15/send/MX2/pre",
+        "output": "/bussend/15/2/pre"
+    },
+    {
+        "input": "/bus/15/send/MX3/lvl",
+        "output": "/bussend/15/3/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/MX3/on",
+        "output": "/bussend/15/3/mix_on"
+    },
+    {
+        "input": "/bus/15/send/MX3/pre",
+        "output": "/bussend/15/3/pre"
+    },
+    {
+        "input": "/bus/15/send/MX4/lvl",
+        "output": "/bussend/15/4/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/MX4/on",
+        "output": "/bussend/15/4/mix_on"
+    },
+    {
+        "input": "/bus/15/send/MX4/pre",
+        "output": "/bussend/15/4/pre"
+    },
+    {
+        "input": "/bus/15/send/MX5/lvl",
+        "output": "/bussend/15/5/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/MX5/on",
+        "output": "/bussend/15/5/mix_on"
+    },
+    {
+        "input": "/bus/15/send/MX5/pre",
+        "output": "/bussend/15/5/pre"
+    },
+    {
+        "input": "/bus/15/send/MX6/lvl",
+        "output": "/bussend/15/6/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/MX6/on",
+        "output": "/bussend/15/6/mix_on"
+    },
+    {
+        "input": "/bus/15/send/MX6/pre",
+        "output": "/bussend/15/6/pre"
+    },
+    {
+        "input": "/bus/15/send/MX7/lvl",
+        "output": "/bussend/15/7/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/MX7/on",
+        "output": "/bussend/15/7/mix_on"
+    },
+    {
+        "input": "/bus/15/send/MX7/pre",
+        "output": "/bussend/15/7/pre"
+    },
+    {
+        "input": "/bus/15/send/MX8/lvl",
+        "output": "/bussend/15/8/mix_fader"
+    },
+    {
+        "input": "/bus/15/send/MX8/on",
+        "output": "/bussend/15/8/mix_on"
+    },
+    {
+        "input": "/bus/15/send/MX8/pre",
+        "output": "/bussend/15/8/pre"
+    },
+    {
+        "input": "/bus/16/col",
+        "output": "/bus/16/config_color"
+    },
+    {
+        "input": "/bus/16/fdr",
+        "output": "/bus/16/mix_fader"
+    },
+    {
+        "input": "/bus/16/main/1/lvl",
+        "output": "/busmainsend/16/1/mix_fader"
+    },
+    {
+        "input": "/bus/16/main/1/on",
+        "output": "/busmainsend/16/1/mix_on"
+    },
+    {
+        "input": "/bus/16/main/1/pre",
+        "output": "/busmainsend/16/1/pre"
+    },
+    {
+        "input": "/bus/16/main/2/lvl",
+        "output": "/busmainsend/16/2/mix_fader"
+    },
+    {
+        "input": "/bus/16/main/2/on",
+        "output": "/busmainsend/16/2/mix_on"
+    },
+    {
+        "input": "/bus/16/main/2/pre",
+        "output": "/busmainsend/16/2/pre"
+    },
+    {
+        "input": "/bus/16/main/3/lvl",
+        "output": "/busmainsend/16/3/mix_fader"
+    },
+    {
+        "input": "/bus/16/main/3/on",
+        "output": "/busmainsend/16/3/mix_on"
+    },
+    {
+        "input": "/bus/16/main/3/pre",
+        "output": "/busmainsend/16/3/pre"
+    },
+    {
+        "input": "/bus/16/main/4/lvl",
+        "output": "/busmainsend/16/4/mix_fader"
+    },
+    {
+        "input": "/bus/16/main/4/on",
+        "output": "/busmainsend/16/4/mix_on"
+    },
+    {
+        "input": "/bus/16/main/4/pre",
+        "output": "/busmainsend/16/4/pre"
+    },
+    {
+        "input": "/bus/16/mute",
+        "output": "/bus/16/mix_on"
+    },
+    {
+        "input": "/bus/16/name",
+        "output": "/bus/16/config_name"
+    },
+    {
+        "input": "/bus/16/send/1/lvl",
+        "output": "/busbussend/16/1/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/1/on",
+        "output": "/busbussend/16/1/mix_on"
+    },
+    {
+        "input": "/bus/16/send/1/pre",
+        "output": "/busbussend/16/1/pre"
+    },
+    {
+        "input": "/bus/16/send/10/lvl",
+        "output": "/busbussend/16/10/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/10/on",
+        "output": "/busbussend/16/10/mix_on"
+    },
+    {
+        "input": "/bus/16/send/10/pre",
+        "output": "/busbussend/16/10/pre"
+    },
+    {
+        "input": "/bus/16/send/11/lvl",
+        "output": "/busbussend/16/11/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/11/on",
+        "output": "/busbussend/16/11/mix_on"
+    },
+    {
+        "input": "/bus/16/send/11/pre",
+        "output": "/busbussend/16/11/pre"
+    },
+    {
+        "input": "/bus/16/send/12/lvl",
+        "output": "/busbussend/16/12/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/12/on",
+        "output": "/busbussend/16/12/mix_on"
+    },
+    {
+        "input": "/bus/16/send/12/pre",
+        "output": "/busbussend/16/12/pre"
+    },
+    {
+        "input": "/bus/16/send/13/lvl",
+        "output": "/busbussend/16/13/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/13/on",
+        "output": "/busbussend/16/13/mix_on"
+    },
+    {
+        "input": "/bus/16/send/13/pre",
+        "output": "/busbussend/16/13/pre"
+    },
+    {
+        "input": "/bus/16/send/14/lvl",
+        "output": "/busbussend/16/14/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/14/on",
+        "output": "/busbussend/16/14/mix_on"
+    },
+    {
+        "input": "/bus/16/send/14/pre",
+        "output": "/busbussend/16/14/pre"
+    },
+    {
+        "input": "/bus/16/send/15/lvl",
+        "output": "/busbussend/16/15/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/15/on",
+        "output": "/busbussend/16/15/mix_on"
+    },
+    {
+        "input": "/bus/16/send/15/pre",
+        "output": "/busbussend/16/15/pre"
+    },
+    {
+        "input": "/bus/16/send/2/lvl",
+        "output": "/busbussend/16/2/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/2/on",
+        "output": "/busbussend/16/2/mix_on"
+    },
+    {
+        "input": "/bus/16/send/2/pre",
+        "output": "/busbussend/16/2/pre"
+    },
+    {
+        "input": "/bus/16/send/3/lvl",
+        "output": "/busbussend/16/3/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/3/on",
+        "output": "/busbussend/16/3/mix_on"
+    },
+    {
+        "input": "/bus/16/send/3/pre",
+        "output": "/busbussend/16/3/pre"
+    },
+    {
+        "input": "/bus/16/send/4/lvl",
+        "output": "/busbussend/16/4/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/4/on",
+        "output": "/busbussend/16/4/mix_on"
+    },
+    {
+        "input": "/bus/16/send/4/pre",
+        "output": "/busbussend/16/4/pre"
+    },
+    {
+        "input": "/bus/16/send/5/lvl",
+        "output": "/busbussend/16/5/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/5/on",
+        "output": "/busbussend/16/5/mix_on"
+    },
+    {
+        "input": "/bus/16/send/5/pre",
+        "output": "/busbussend/16/5/pre"
+    },
+    {
+        "input": "/bus/16/send/6/lvl",
+        "output": "/busbussend/16/6/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/6/on",
+        "output": "/busbussend/16/6/mix_on"
+    },
+    {
+        "input": "/bus/16/send/6/pre",
+        "output": "/busbussend/16/6/pre"
+    },
+    {
+        "input": "/bus/16/send/7/lvl",
+        "output": "/busbussend/16/7/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/7/on",
+        "output": "/busbussend/16/7/mix_on"
+    },
+    {
+        "input": "/bus/16/send/7/pre",
+        "output": "/busbussend/16/7/pre"
+    },
+    {
+        "input": "/bus/16/send/8/lvl",
+        "output": "/busbussend/16/8/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/8/on",
+        "output": "/busbussend/16/8/mix_on"
+    },
+    {
+        "input": "/bus/16/send/8/pre",
+        "output": "/busbussend/16/8/pre"
+    },
+    {
+        "input": "/bus/16/send/9/lvl",
+        "output": "/busbussend/16/9/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/9/on",
+        "output": "/busbussend/16/9/mix_on"
+    },
+    {
+        "input": "/bus/16/send/9/pre",
+        "output": "/busbussend/16/9/pre"
+    },
+    {
+        "input": "/bus/16/send/MX1/lvl",
+        "output": "/bussend/16/1/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/MX1/on",
+        "output": "/bussend/16/1/mix_on"
+    },
+    {
+        "input": "/bus/16/send/MX1/pre",
+        "output": "/bussend/16/1/pre"
+    },
+    {
+        "input": "/bus/16/send/MX2/lvl",
+        "output": "/bussend/16/2/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/MX2/on",
+        "output": "/bussend/16/2/mix_on"
+    },
+    {
+        "input": "/bus/16/send/MX2/pre",
+        "output": "/bussend/16/2/pre"
+    },
+    {
+        "input": "/bus/16/send/MX3/lvl",
+        "output": "/bussend/16/3/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/MX3/on",
+        "output": "/bussend/16/3/mix_on"
+    },
+    {
+        "input": "/bus/16/send/MX3/pre",
+        "output": "/bussend/16/3/pre"
+    },
+    {
+        "input": "/bus/16/send/MX4/lvl",
+        "output": "/bussend/16/4/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/MX4/on",
+        "output": "/bussend/16/4/mix_on"
+    },
+    {
+        "input": "/bus/16/send/MX4/pre",
+        "output": "/bussend/16/4/pre"
+    },
+    {
+        "input": "/bus/16/send/MX5/lvl",
+        "output": "/bussend/16/5/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/MX5/on",
+        "output": "/bussend/16/5/mix_on"
+    },
+    {
+        "input": "/bus/16/send/MX5/pre",
+        "output": "/bussend/16/5/pre"
+    },
+    {
+        "input": "/bus/16/send/MX6/lvl",
+        "output": "/bussend/16/6/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/MX6/on",
+        "output": "/bussend/16/6/mix_on"
+    },
+    {
+        "input": "/bus/16/send/MX6/pre",
+        "output": "/bussend/16/6/pre"
+    },
+    {
+        "input": "/bus/16/send/MX7/lvl",
+        "output": "/bussend/16/7/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/MX7/on",
+        "output": "/bussend/16/7/mix_on"
+    },
+    {
+        "input": "/bus/16/send/MX7/pre",
+        "output": "/bussend/16/7/pre"
+    },
+    {
+        "input": "/bus/16/send/MX8/lvl",
+        "output": "/bussend/16/8/mix_fader"
+    },
+    {
+        "input": "/bus/16/send/MX8/on",
+        "output": "/bussend/16/8/mix_on"
+    },
+    {
+        "input": "/bus/16/send/MX8/pre",
+        "output": "/bussend/16/8/pre"
+    },
+    {
+        "input": "/bus/2/col",
+        "output": "/bus/2/config_color"
+    },
+    {
+        "input": "/bus/2/fdr",
+        "output": "/bus/2/mix_fader"
+    },
+    {
+        "input": "/bus/2/main/1/lvl",
+        "output": "/busmainsend/2/1/mix_fader"
+    },
+    {
+        "input": "/bus/2/main/1/on",
+        "output": "/busmainsend/2/1/mix_on"
+    },
+    {
+        "input": "/bus/2/main/1/pre",
+        "output": "/busmainsend/2/1/pre"
+    },
+    {
+        "input": "/bus/2/main/2/lvl",
+        "output": "/busmainsend/2/2/mix_fader"
+    },
+    {
+        "input": "/bus/2/main/2/on",
+        "output": "/busmainsend/2/2/mix_on"
+    },
+    {
+        "input": "/bus/2/main/2/pre",
+        "output": "/busmainsend/2/2/pre"
+    },
+    {
+        "input": "/bus/2/main/3/lvl",
+        "output": "/busmainsend/2/3/mix_fader"
+    },
+    {
+        "input": "/bus/2/main/3/on",
+        "output": "/busmainsend/2/3/mix_on"
+    },
+    {
+        "input": "/bus/2/main/3/pre",
+        "output": "/busmainsend/2/3/pre"
+    },
+    {
+        "input": "/bus/2/main/4/lvl",
+        "output": "/busmainsend/2/4/mix_fader"
+    },
+    {
+        "input": "/bus/2/main/4/on",
+        "output": "/busmainsend/2/4/mix_on"
+    },
+    {
+        "input": "/bus/2/main/4/pre",
+        "output": "/busmainsend/2/4/pre"
+    },
+    {
+        "input": "/bus/2/mute",
+        "output": "/bus/2/mix_on"
+    },
+    {
+        "input": "/bus/2/name",
+        "output": "/bus/2/config_name"
+    },
+    {
+        "input": "/bus/2/send/1/lvl",
+        "output": "/busbussend/2/1/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/1/on",
+        "output": "/busbussend/2/1/mix_on"
+    },
+    {
+        "input": "/bus/2/send/1/pre",
+        "output": "/busbussend/2/1/pre"
+    },
+    {
+        "input": "/bus/2/send/10/lvl",
+        "output": "/busbussend/2/10/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/10/on",
+        "output": "/busbussend/2/10/mix_on"
+    },
+    {
+        "input": "/bus/2/send/10/pre",
+        "output": "/busbussend/2/10/pre"
+    },
+    {
+        "input": "/bus/2/send/11/lvl",
+        "output": "/busbussend/2/11/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/11/on",
+        "output": "/busbussend/2/11/mix_on"
+    },
+    {
+        "input": "/bus/2/send/11/pre",
+        "output": "/busbussend/2/11/pre"
+    },
+    {
+        "input": "/bus/2/send/12/lvl",
+        "output": "/busbussend/2/12/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/12/on",
+        "output": "/busbussend/2/12/mix_on"
+    },
+    {
+        "input": "/bus/2/send/12/pre",
+        "output": "/busbussend/2/12/pre"
+    },
+    {
+        "input": "/bus/2/send/13/lvl",
+        "output": "/busbussend/2/13/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/13/on",
+        "output": "/busbussend/2/13/mix_on"
+    },
+    {
+        "input": "/bus/2/send/13/pre",
+        "output": "/busbussend/2/13/pre"
+    },
+    {
+        "input": "/bus/2/send/14/lvl",
+        "output": "/busbussend/2/14/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/14/on",
+        "output": "/busbussend/2/14/mix_on"
+    },
+    {
+        "input": "/bus/2/send/14/pre",
+        "output": "/busbussend/2/14/pre"
+    },
+    {
+        "input": "/bus/2/send/15/lvl",
+        "output": "/busbussend/2/15/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/15/on",
+        "output": "/busbussend/2/15/mix_on"
+    },
+    {
+        "input": "/bus/2/send/15/pre",
+        "output": "/busbussend/2/15/pre"
+    },
+    {
+        "input": "/bus/2/send/16/lvl",
+        "output": "/busbussend/2/16/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/16/on",
+        "output": "/busbussend/2/16/mix_on"
+    },
+    {
+        "input": "/bus/2/send/16/pre",
+        "output": "/busbussend/2/16/pre"
+    },
+    {
+        "input": "/bus/2/send/3/lvl",
+        "output": "/busbussend/2/3/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/3/on",
+        "output": "/busbussend/2/3/mix_on"
+    },
+    {
+        "input": "/bus/2/send/3/pre",
+        "output": "/busbussend/2/3/pre"
+    },
+    {
+        "input": "/bus/2/send/4/lvl",
+        "output": "/busbussend/2/4/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/4/on",
+        "output": "/busbussend/2/4/mix_on"
+    },
+    {
+        "input": "/bus/2/send/4/pre",
+        "output": "/busbussend/2/4/pre"
+    },
+    {
+        "input": "/bus/2/send/5/lvl",
+        "output": "/busbussend/2/5/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/5/on",
+        "output": "/busbussend/2/5/mix_on"
+    },
+    {
+        "input": "/bus/2/send/5/pre",
+        "output": "/busbussend/2/5/pre"
+    },
+    {
+        "input": "/bus/2/send/6/lvl",
+        "output": "/busbussend/2/6/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/6/on",
+        "output": "/busbussend/2/6/mix_on"
+    },
+    {
+        "input": "/bus/2/send/6/pre",
+        "output": "/busbussend/2/6/pre"
+    },
+    {
+        "input": "/bus/2/send/7/lvl",
+        "output": "/busbussend/2/7/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/7/on",
+        "output": "/busbussend/2/7/mix_on"
+    },
+    {
+        "input": "/bus/2/send/7/pre",
+        "output": "/busbussend/2/7/pre"
+    },
+    {
+        "input": "/bus/2/send/8/lvl",
+        "output": "/busbussend/2/8/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/8/on",
+        "output": "/busbussend/2/8/mix_on"
+    },
+    {
+        "input": "/bus/2/send/8/pre",
+        "output": "/busbussend/2/8/pre"
+    },
+    {
+        "input": "/bus/2/send/9/lvl",
+        "output": "/busbussend/2/9/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/9/on",
+        "output": "/busbussend/2/9/mix_on"
+    },
+    {
+        "input": "/bus/2/send/9/pre",
+        "output": "/busbussend/2/9/pre"
+    },
+    {
+        "input": "/bus/2/send/MX1/lvl",
+        "output": "/bussend/2/1/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/MX1/on",
+        "output": "/bussend/2/1/mix_on"
+    },
+    {
+        "input": "/bus/2/send/MX1/pre",
+        "output": "/bussend/2/1/pre"
+    },
+    {
+        "input": "/bus/2/send/MX2/lvl",
+        "output": "/bussend/2/2/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/MX2/on",
+        "output": "/bussend/2/2/mix_on"
+    },
+    {
+        "input": "/bus/2/send/MX2/pre",
+        "output": "/bussend/2/2/pre"
+    },
+    {
+        "input": "/bus/2/send/MX3/lvl",
+        "output": "/bussend/2/3/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/MX3/on",
+        "output": "/bussend/2/3/mix_on"
+    },
+    {
+        "input": "/bus/2/send/MX3/pre",
+        "output": "/bussend/2/3/pre"
+    },
+    {
+        "input": "/bus/2/send/MX4/lvl",
+        "output": "/bussend/2/4/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/MX4/on",
+        "output": "/bussend/2/4/mix_on"
+    },
+    {
+        "input": "/bus/2/send/MX4/pre",
+        "output": "/bussend/2/4/pre"
+    },
+    {
+        "input": "/bus/2/send/MX5/lvl",
+        "output": "/bussend/2/5/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/MX5/on",
+        "output": "/bussend/2/5/mix_on"
+    },
+    {
+        "input": "/bus/2/send/MX5/pre",
+        "output": "/bussend/2/5/pre"
+    },
+    {
+        "input": "/bus/2/send/MX6/lvl",
+        "output": "/bussend/2/6/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/MX6/on",
+        "output": "/bussend/2/6/mix_on"
+    },
+    {
+        "input": "/bus/2/send/MX6/pre",
+        "output": "/bussend/2/6/pre"
+    },
+    {
+        "input": "/bus/2/send/MX7/lvl",
+        "output": "/bussend/2/7/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/MX7/on",
+        "output": "/bussend/2/7/mix_on"
+    },
+    {
+        "input": "/bus/2/send/MX7/pre",
+        "output": "/bussend/2/7/pre"
+    },
+    {
+        "input": "/bus/2/send/MX8/lvl",
+        "output": "/bussend/2/8/mix_fader"
+    },
+    {
+        "input": "/bus/2/send/MX8/on",
+        "output": "/bussend/2/8/mix_on"
+    },
+    {
+        "input": "/bus/2/send/MX8/pre",
+        "output": "/bussend/2/8/pre"
+    },
+    {
+        "input": "/bus/3/col",
+        "output": "/bus/3/config_color"
+    },
+    {
+        "input": "/bus/3/fdr",
+        "output": "/bus/3/mix_fader"
+    },
+    {
+        "input": "/bus/3/main/1/lvl",
+        "output": "/busmainsend/3/1/mix_fader"
+    },
+    {
+        "input": "/bus/3/main/1/on",
+        "output": "/busmainsend/3/1/mix_on"
+    },
+    {
+        "input": "/bus/3/main/1/pre",
+        "output": "/busmainsend/3/1/pre"
+    },
+    {
+        "input": "/bus/3/main/2/lvl",
+        "output": "/busmainsend/3/2/mix_fader"
+    },
+    {
+        "input": "/bus/3/main/2/on",
+        "output": "/busmainsend/3/2/mix_on"
+    },
+    {
+        "input": "/bus/3/main/2/pre",
+        "output": "/busmainsend/3/2/pre"
+    },
+    {
+        "input": "/bus/3/main/3/lvl",
+        "output": "/busmainsend/3/3/mix_fader"
+    },
+    {
+        "input": "/bus/3/main/3/on",
+        "output": "/busmainsend/3/3/mix_on"
+    },
+    {
+        "input": "/bus/3/main/3/pre",
+        "output": "/busmainsend/3/3/pre"
+    },
+    {
+        "input": "/bus/3/main/4/lvl",
+        "output": "/busmainsend/3/4/mix_fader"
+    },
+    {
+        "input": "/bus/3/main/4/on",
+        "output": "/busmainsend/3/4/mix_on"
+    },
+    {
+        "input": "/bus/3/main/4/pre",
+        "output": "/busmainsend/3/4/pre"
+    },
+    {
+        "input": "/bus/3/mute",
+        "output": "/bus/3/mix_on"
+    },
+    {
+        "input": "/bus/3/name",
+        "output": "/bus/3/config_name"
+    },
+    {
+        "input": "/bus/3/send/1/lvl",
+        "output": "/busbussend/3/1/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/1/on",
+        "output": "/busbussend/3/1/mix_on"
+    },
+    {
+        "input": "/bus/3/send/1/pre",
+        "output": "/busbussend/3/1/pre"
+    },
+    {
+        "input": "/bus/3/send/10/lvl",
+        "output": "/busbussend/3/10/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/10/on",
+        "output": "/busbussend/3/10/mix_on"
+    },
+    {
+        "input": "/bus/3/send/10/pre",
+        "output": "/busbussend/3/10/pre"
+    },
+    {
+        "input": "/bus/3/send/11/lvl",
+        "output": "/busbussend/3/11/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/11/on",
+        "output": "/busbussend/3/11/mix_on"
+    },
+    {
+        "input": "/bus/3/send/11/pre",
+        "output": "/busbussend/3/11/pre"
+    },
+    {
+        "input": "/bus/3/send/12/lvl",
+        "output": "/busbussend/3/12/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/12/on",
+        "output": "/busbussend/3/12/mix_on"
+    },
+    {
+        "input": "/bus/3/send/12/pre",
+        "output": "/busbussend/3/12/pre"
+    },
+    {
+        "input": "/bus/3/send/13/lvl",
+        "output": "/busbussend/3/13/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/13/on",
+        "output": "/busbussend/3/13/mix_on"
+    },
+    {
+        "input": "/bus/3/send/13/pre",
+        "output": "/busbussend/3/13/pre"
+    },
+    {
+        "input": "/bus/3/send/14/lvl",
+        "output": "/busbussend/3/14/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/14/on",
+        "output": "/busbussend/3/14/mix_on"
+    },
+    {
+        "input": "/bus/3/send/14/pre",
+        "output": "/busbussend/3/14/pre"
+    },
+    {
+        "input": "/bus/3/send/15/lvl",
+        "output": "/busbussend/3/15/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/15/on",
+        "output": "/busbussend/3/15/mix_on"
+    },
+    {
+        "input": "/bus/3/send/15/pre",
+        "output": "/busbussend/3/15/pre"
+    },
+    {
+        "input": "/bus/3/send/16/lvl",
+        "output": "/busbussend/3/16/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/16/on",
+        "output": "/busbussend/3/16/mix_on"
+    },
+    {
+        "input": "/bus/3/send/16/pre",
+        "output": "/busbussend/3/16/pre"
+    },
+    {
+        "input": "/bus/3/send/2/lvl",
+        "output": "/busbussend/3/2/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/2/on",
+        "output": "/busbussend/3/2/mix_on"
+    },
+    {
+        "input": "/bus/3/send/2/pre",
+        "output": "/busbussend/3/2/pre"
+    },
+    {
+        "input": "/bus/3/send/4/lvl",
+        "output": "/busbussend/3/4/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/4/on",
+        "output": "/busbussend/3/4/mix_on"
+    },
+    {
+        "input": "/bus/3/send/4/pre",
+        "output": "/busbussend/3/4/pre"
+    },
+    {
+        "input": "/bus/3/send/5/lvl",
+        "output": "/busbussend/3/5/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/5/on",
+        "output": "/busbussend/3/5/mix_on"
+    },
+    {
+        "input": "/bus/3/send/5/pre",
+        "output": "/busbussend/3/5/pre"
+    },
+    {
+        "input": "/bus/3/send/6/lvl",
+        "output": "/busbussend/3/6/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/6/on",
+        "output": "/busbussend/3/6/mix_on"
+    },
+    {
+        "input": "/bus/3/send/6/pre",
+        "output": "/busbussend/3/6/pre"
+    },
+    {
+        "input": "/bus/3/send/7/lvl",
+        "output": "/busbussend/3/7/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/7/on",
+        "output": "/busbussend/3/7/mix_on"
+    },
+    {
+        "input": "/bus/3/send/7/pre",
+        "output": "/busbussend/3/7/pre"
+    },
+    {
+        "input": "/bus/3/send/8/lvl",
+        "output": "/busbussend/3/8/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/8/on",
+        "output": "/busbussend/3/8/mix_on"
+    },
+    {
+        "input": "/bus/3/send/8/pre",
+        "output": "/busbussend/3/8/pre"
+    },
+    {
+        "input": "/bus/3/send/9/lvl",
+        "output": "/busbussend/3/9/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/9/on",
+        "output": "/busbussend/3/9/mix_on"
+    },
+    {
+        "input": "/bus/3/send/9/pre",
+        "output": "/busbussend/3/9/pre"
+    },
+    {
+        "input": "/bus/3/send/MX1/lvl",
+        "output": "/bussend/3/1/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/MX1/on",
+        "output": "/bussend/3/1/mix_on"
+    },
+    {
+        "input": "/bus/3/send/MX1/pre",
+        "output": "/bussend/3/1/pre"
+    },
+    {
+        "input": "/bus/3/send/MX2/lvl",
+        "output": "/bussend/3/2/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/MX2/on",
+        "output": "/bussend/3/2/mix_on"
+    },
+    {
+        "input": "/bus/3/send/MX2/pre",
+        "output": "/bussend/3/2/pre"
+    },
+    {
+        "input": "/bus/3/send/MX3/lvl",
+        "output": "/bussend/3/3/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/MX3/on",
+        "output": "/bussend/3/3/mix_on"
+    },
+    {
+        "input": "/bus/3/send/MX3/pre",
+        "output": "/bussend/3/3/pre"
+    },
+    {
+        "input": "/bus/3/send/MX4/lvl",
+        "output": "/bussend/3/4/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/MX4/on",
+        "output": "/bussend/3/4/mix_on"
+    },
+    {
+        "input": "/bus/3/send/MX4/pre",
+        "output": "/bussend/3/4/pre"
+    },
+    {
+        "input": "/bus/3/send/MX5/lvl",
+        "output": "/bussend/3/5/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/MX5/on",
+        "output": "/bussend/3/5/mix_on"
+    },
+    {
+        "input": "/bus/3/send/MX5/pre",
+        "output": "/bussend/3/5/pre"
+    },
+    {
+        "input": "/bus/3/send/MX6/lvl",
+        "output": "/bussend/3/6/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/MX6/on",
+        "output": "/bussend/3/6/mix_on"
+    },
+    {
+        "input": "/bus/3/send/MX6/pre",
+        "output": "/bussend/3/6/pre"
+    },
+    {
+        "input": "/bus/3/send/MX7/lvl",
+        "output": "/bussend/3/7/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/MX7/on",
+        "output": "/bussend/3/7/mix_on"
+    },
+    {
+        "input": "/bus/3/send/MX7/pre",
+        "output": "/bussend/3/7/pre"
+    },
+    {
+        "input": "/bus/3/send/MX8/lvl",
+        "output": "/bussend/3/8/mix_fader"
+    },
+    {
+        "input": "/bus/3/send/MX8/on",
+        "output": "/bussend/3/8/mix_on"
+    },
+    {
+        "input": "/bus/3/send/MX8/pre",
+        "output": "/bussend/3/8/pre"
+    },
+    {
+        "input": "/bus/4/col",
+        "output": "/bus/4/config_color"
+    },
+    {
+        "input": "/bus/4/fdr",
+        "output": "/bus/4/mix_fader"
+    },
+    {
+        "input": "/bus/4/main/1/lvl",
+        "output": "/busmainsend/4/1/mix_fader"
+    },
+    {
+        "input": "/bus/4/main/1/on",
+        "output": "/busmainsend/4/1/mix_on"
+    },
+    {
+        "input": "/bus/4/main/1/pre",
+        "output": "/busmainsend/4/1/pre"
+    },
+    {
+        "input": "/bus/4/main/2/lvl",
+        "output": "/busmainsend/4/2/mix_fader"
+    },
+    {
+        "input": "/bus/4/main/2/on",
+        "output": "/busmainsend/4/2/mix_on"
+    },
+    {
+        "input": "/bus/4/main/2/pre",
+        "output": "/busmainsend/4/2/pre"
+    },
+    {
+        "input": "/bus/4/main/3/lvl",
+        "output": "/busmainsend/4/3/mix_fader"
+    },
+    {
+        "input": "/bus/4/main/3/on",
+        "output": "/busmainsend/4/3/mix_on"
+    },
+    {
+        "input": "/bus/4/main/3/pre",
+        "output": "/busmainsend/4/3/pre"
+    },
+    {
+        "input": "/bus/4/main/4/lvl",
+        "output": "/busmainsend/4/4/mix_fader"
+    },
+    {
+        "input": "/bus/4/main/4/on",
+        "output": "/busmainsend/4/4/mix_on"
+    },
+    {
+        "input": "/bus/4/main/4/pre",
+        "output": "/busmainsend/4/4/pre"
+    },
+    {
+        "input": "/bus/4/mute",
+        "output": "/bus/4/mix_on"
+    },
+    {
+        "input": "/bus/4/name",
+        "output": "/bus/4/config_name"
+    },
+    {
+        "input": "/bus/4/send/1/lvl",
+        "output": "/busbussend/4/1/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/1/on",
+        "output": "/busbussend/4/1/mix_on"
+    },
+    {
+        "input": "/bus/4/send/1/pre",
+        "output": "/busbussend/4/1/pre"
+    },
+    {
+        "input": "/bus/4/send/10/lvl",
+        "output": "/busbussend/4/10/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/10/on",
+        "output": "/busbussend/4/10/mix_on"
+    },
+    {
+        "input": "/bus/4/send/10/pre",
+        "output": "/busbussend/4/10/pre"
+    },
+    {
+        "input": "/bus/4/send/11/lvl",
+        "output": "/busbussend/4/11/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/11/on",
+        "output": "/busbussend/4/11/mix_on"
+    },
+    {
+        "input": "/bus/4/send/11/pre",
+        "output": "/busbussend/4/11/pre"
+    },
+    {
+        "input": "/bus/4/send/12/lvl",
+        "output": "/busbussend/4/12/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/12/on",
+        "output": "/busbussend/4/12/mix_on"
+    },
+    {
+        "input": "/bus/4/send/12/pre",
+        "output": "/busbussend/4/12/pre"
+    },
+    {
+        "input": "/bus/4/send/13/lvl",
+        "output": "/busbussend/4/13/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/13/on",
+        "output": "/busbussend/4/13/mix_on"
+    },
+    {
+        "input": "/bus/4/send/13/pre",
+        "output": "/busbussend/4/13/pre"
+    },
+    {
+        "input": "/bus/4/send/14/lvl",
+        "output": "/busbussend/4/14/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/14/on",
+        "output": "/busbussend/4/14/mix_on"
+    },
+    {
+        "input": "/bus/4/send/14/pre",
+        "output": "/busbussend/4/14/pre"
+    },
+    {
+        "input": "/bus/4/send/15/lvl",
+        "output": "/busbussend/4/15/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/15/on",
+        "output": "/busbussend/4/15/mix_on"
+    },
+    {
+        "input": "/bus/4/send/15/pre",
+        "output": "/busbussend/4/15/pre"
+    },
+    {
+        "input": "/bus/4/send/16/lvl",
+        "output": "/busbussend/4/16/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/16/on",
+        "output": "/busbussend/4/16/mix_on"
+    },
+    {
+        "input": "/bus/4/send/16/pre",
+        "output": "/busbussend/4/16/pre"
+    },
+    {
+        "input": "/bus/4/send/2/lvl",
+        "output": "/busbussend/4/2/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/2/on",
+        "output": "/busbussend/4/2/mix_on"
+    },
+    {
+        "input": "/bus/4/send/2/pre",
+        "output": "/busbussend/4/2/pre"
+    },
+    {
+        "input": "/bus/4/send/3/lvl",
+        "output": "/busbussend/4/3/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/3/on",
+        "output": "/busbussend/4/3/mix_on"
+    },
+    {
+        "input": "/bus/4/send/3/pre",
+        "output": "/busbussend/4/3/pre"
+    },
+    {
+        "input": "/bus/4/send/5/lvl",
+        "output": "/busbussend/4/5/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/5/on",
+        "output": "/busbussend/4/5/mix_on"
+    },
+    {
+        "input": "/bus/4/send/5/pre",
+        "output": "/busbussend/4/5/pre"
+    },
+    {
+        "input": "/bus/4/send/6/lvl",
+        "output": "/busbussend/4/6/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/6/on",
+        "output": "/busbussend/4/6/mix_on"
+    },
+    {
+        "input": "/bus/4/send/6/pre",
+        "output": "/busbussend/4/6/pre"
+    },
+    {
+        "input": "/bus/4/send/7/lvl",
+        "output": "/busbussend/4/7/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/7/on",
+        "output": "/busbussend/4/7/mix_on"
+    },
+    {
+        "input": "/bus/4/send/7/pre",
+        "output": "/busbussend/4/7/pre"
+    },
+    {
+        "input": "/bus/4/send/8/lvl",
+        "output": "/busbussend/4/8/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/8/on",
+        "output": "/busbussend/4/8/mix_on"
+    },
+    {
+        "input": "/bus/4/send/8/pre",
+        "output": "/busbussend/4/8/pre"
+    },
+    {
+        "input": "/bus/4/send/9/lvl",
+        "output": "/busbussend/4/9/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/9/on",
+        "output": "/busbussend/4/9/mix_on"
+    },
+    {
+        "input": "/bus/4/send/9/pre",
+        "output": "/busbussend/4/9/pre"
+    },
+    {
+        "input": "/bus/4/send/MX1/lvl",
+        "output": "/bussend/4/1/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/MX1/on",
+        "output": "/bussend/4/1/mix_on"
+    },
+    {
+        "input": "/bus/4/send/MX1/pre",
+        "output": "/bussend/4/1/pre"
+    },
+    {
+        "input": "/bus/4/send/MX2/lvl",
+        "output": "/bussend/4/2/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/MX2/on",
+        "output": "/bussend/4/2/mix_on"
+    },
+    {
+        "input": "/bus/4/send/MX2/pre",
+        "output": "/bussend/4/2/pre"
+    },
+    {
+        "input": "/bus/4/send/MX3/lvl",
+        "output": "/bussend/4/3/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/MX3/on",
+        "output": "/bussend/4/3/mix_on"
+    },
+    {
+        "input": "/bus/4/send/MX3/pre",
+        "output": "/bussend/4/3/pre"
+    },
+    {
+        "input": "/bus/4/send/MX4/lvl",
+        "output": "/bussend/4/4/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/MX4/on",
+        "output": "/bussend/4/4/mix_on"
+    },
+    {
+        "input": "/bus/4/send/MX4/pre",
+        "output": "/bussend/4/4/pre"
+    },
+    {
+        "input": "/bus/4/send/MX5/lvl",
+        "output": "/bussend/4/5/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/MX5/on",
+        "output": "/bussend/4/5/mix_on"
+    },
+    {
+        "input": "/bus/4/send/MX5/pre",
+        "output": "/bussend/4/5/pre"
+    },
+    {
+        "input": "/bus/4/send/MX6/lvl",
+        "output": "/bussend/4/6/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/MX6/on",
+        "output": "/bussend/4/6/mix_on"
+    },
+    {
+        "input": "/bus/4/send/MX6/pre",
+        "output": "/bussend/4/6/pre"
+    },
+    {
+        "input": "/bus/4/send/MX7/lvl",
+        "output": "/bussend/4/7/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/MX7/on",
+        "output": "/bussend/4/7/mix_on"
+    },
+    {
+        "input": "/bus/4/send/MX7/pre",
+        "output": "/bussend/4/7/pre"
+    },
+    {
+        "input": "/bus/4/send/MX8/lvl",
+        "output": "/bussend/4/8/mix_fader"
+    },
+    {
+        "input": "/bus/4/send/MX8/on",
+        "output": "/bussend/4/8/mix_on"
+    },
+    {
+        "input": "/bus/4/send/MX8/pre",
+        "output": "/bussend/4/8/pre"
+    },
+    {
+        "input": "/bus/5/col",
+        "output": "/bus/5/config_color"
+    },
+    {
+        "input": "/bus/5/fdr",
+        "output": "/bus/5/mix_fader"
+    },
+    {
+        "input": "/bus/5/main/1/lvl",
+        "output": "/busmainsend/5/1/mix_fader"
+    },
+    {
+        "input": "/bus/5/main/1/on",
+        "output": "/busmainsend/5/1/mix_on"
+    },
+    {
+        "input": "/bus/5/main/1/pre",
+        "output": "/busmainsend/5/1/pre"
+    },
+    {
+        "input": "/bus/5/main/2/lvl",
+        "output": "/busmainsend/5/2/mix_fader"
+    },
+    {
+        "input": "/bus/5/main/2/on",
+        "output": "/busmainsend/5/2/mix_on"
+    },
+    {
+        "input": "/bus/5/main/2/pre",
+        "output": "/busmainsend/5/2/pre"
+    },
+    {
+        "input": "/bus/5/main/3/lvl",
+        "output": "/busmainsend/5/3/mix_fader"
+    },
+    {
+        "input": "/bus/5/main/3/on",
+        "output": "/busmainsend/5/3/mix_on"
+    },
+    {
+        "input": "/bus/5/main/3/pre",
+        "output": "/busmainsend/5/3/pre"
+    },
+    {
+        "input": "/bus/5/main/4/lvl",
+        "output": "/busmainsend/5/4/mix_fader"
+    },
+    {
+        "input": "/bus/5/main/4/on",
+        "output": "/busmainsend/5/4/mix_on"
+    },
+    {
+        "input": "/bus/5/main/4/pre",
+        "output": "/busmainsend/5/4/pre"
+    },
+    {
+        "input": "/bus/5/mute",
+        "output": "/bus/5/mix_on"
+    },
+    {
+        "input": "/bus/5/name",
+        "output": "/bus/5/config_name"
+    },
+    {
+        "input": "/bus/5/send/1/lvl",
+        "output": "/busbussend/5/1/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/1/on",
+        "output": "/busbussend/5/1/mix_on"
+    },
+    {
+        "input": "/bus/5/send/1/pre",
+        "output": "/busbussend/5/1/pre"
+    },
+    {
+        "input": "/bus/5/send/10/lvl",
+        "output": "/busbussend/5/10/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/10/on",
+        "output": "/busbussend/5/10/mix_on"
+    },
+    {
+        "input": "/bus/5/send/10/pre",
+        "output": "/busbussend/5/10/pre"
+    },
+    {
+        "input": "/bus/5/send/11/lvl",
+        "output": "/busbussend/5/11/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/11/on",
+        "output": "/busbussend/5/11/mix_on"
+    },
+    {
+        "input": "/bus/5/send/11/pre",
+        "output": "/busbussend/5/11/pre"
+    },
+    {
+        "input": "/bus/5/send/12/lvl",
+        "output": "/busbussend/5/12/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/12/on",
+        "output": "/busbussend/5/12/mix_on"
+    },
+    {
+        "input": "/bus/5/send/12/pre",
+        "output": "/busbussend/5/12/pre"
+    },
+    {
+        "input": "/bus/5/send/13/lvl",
+        "output": "/busbussend/5/13/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/13/on",
+        "output": "/busbussend/5/13/mix_on"
+    },
+    {
+        "input": "/bus/5/send/13/pre",
+        "output": "/busbussend/5/13/pre"
+    },
+    {
+        "input": "/bus/5/send/14/lvl",
+        "output": "/busbussend/5/14/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/14/on",
+        "output": "/busbussend/5/14/mix_on"
+    },
+    {
+        "input": "/bus/5/send/14/pre",
+        "output": "/busbussend/5/14/pre"
+    },
+    {
+        "input": "/bus/5/send/15/lvl",
+        "output": "/busbussend/5/15/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/15/on",
+        "output": "/busbussend/5/15/mix_on"
+    },
+    {
+        "input": "/bus/5/send/15/pre",
+        "output": "/busbussend/5/15/pre"
+    },
+    {
+        "input": "/bus/5/send/16/lvl",
+        "output": "/busbussend/5/16/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/16/on",
+        "output": "/busbussend/5/16/mix_on"
+    },
+    {
+        "input": "/bus/5/send/16/pre",
+        "output": "/busbussend/5/16/pre"
+    },
+    {
+        "input": "/bus/5/send/2/lvl",
+        "output": "/busbussend/5/2/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/2/on",
+        "output": "/busbussend/5/2/mix_on"
+    },
+    {
+        "input": "/bus/5/send/2/pre",
+        "output": "/busbussend/5/2/pre"
+    },
+    {
+        "input": "/bus/5/send/3/lvl",
+        "output": "/busbussend/5/3/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/3/on",
+        "output": "/busbussend/5/3/mix_on"
+    },
+    {
+        "input": "/bus/5/send/3/pre",
+        "output": "/busbussend/5/3/pre"
+    },
+    {
+        "input": "/bus/5/send/4/lvl",
+        "output": "/busbussend/5/4/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/4/on",
+        "output": "/busbussend/5/4/mix_on"
+    },
+    {
+        "input": "/bus/5/send/4/pre",
+        "output": "/busbussend/5/4/pre"
+    },
+    {
+        "input": "/bus/5/send/6/lvl",
+        "output": "/busbussend/5/6/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/6/on",
+        "output": "/busbussend/5/6/mix_on"
+    },
+    {
+        "input": "/bus/5/send/6/pre",
+        "output": "/busbussend/5/6/pre"
+    },
+    {
+        "input": "/bus/5/send/7/lvl",
+        "output": "/busbussend/5/7/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/7/on",
+        "output": "/busbussend/5/7/mix_on"
+    },
+    {
+        "input": "/bus/5/send/7/pre",
+        "output": "/busbussend/5/7/pre"
+    },
+    {
+        "input": "/bus/5/send/8/lvl",
+        "output": "/busbussend/5/8/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/8/on",
+        "output": "/busbussend/5/8/mix_on"
+    },
+    {
+        "input": "/bus/5/send/8/pre",
+        "output": "/busbussend/5/8/pre"
+    },
+    {
+        "input": "/bus/5/send/9/lvl",
+        "output": "/busbussend/5/9/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/9/on",
+        "output": "/busbussend/5/9/mix_on"
+    },
+    {
+        "input": "/bus/5/send/9/pre",
+        "output": "/busbussend/5/9/pre"
+    },
+    {
+        "input": "/bus/5/send/MX1/lvl",
+        "output": "/bussend/5/1/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/MX1/on",
+        "output": "/bussend/5/1/mix_on"
+    },
+    {
+        "input": "/bus/5/send/MX1/pre",
+        "output": "/bussend/5/1/pre"
+    },
+    {
+        "input": "/bus/5/send/MX2/lvl",
+        "output": "/bussend/5/2/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/MX2/on",
+        "output": "/bussend/5/2/mix_on"
+    },
+    {
+        "input": "/bus/5/send/MX2/pre",
+        "output": "/bussend/5/2/pre"
+    },
+    {
+        "input": "/bus/5/send/MX3/lvl",
+        "output": "/bussend/5/3/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/MX3/on",
+        "output": "/bussend/5/3/mix_on"
+    },
+    {
+        "input": "/bus/5/send/MX3/pre",
+        "output": "/bussend/5/3/pre"
+    },
+    {
+        "input": "/bus/5/send/MX4/lvl",
+        "output": "/bussend/5/4/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/MX4/on",
+        "output": "/bussend/5/4/mix_on"
+    },
+    {
+        "input": "/bus/5/send/MX4/pre",
+        "output": "/bussend/5/4/pre"
+    },
+    {
+        "input": "/bus/5/send/MX5/lvl",
+        "output": "/bussend/5/5/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/MX5/on",
+        "output": "/bussend/5/5/mix_on"
+    },
+    {
+        "input": "/bus/5/send/MX5/pre",
+        "output": "/bussend/5/5/pre"
+    },
+    {
+        "input": "/bus/5/send/MX6/lvl",
+        "output": "/bussend/5/6/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/MX6/on",
+        "output": "/bussend/5/6/mix_on"
+    },
+    {
+        "input": "/bus/5/send/MX6/pre",
+        "output": "/bussend/5/6/pre"
+    },
+    {
+        "input": "/bus/5/send/MX7/lvl",
+        "output": "/bussend/5/7/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/MX7/on",
+        "output": "/bussend/5/7/mix_on"
+    },
+    {
+        "input": "/bus/5/send/MX7/pre",
+        "output": "/bussend/5/7/pre"
+    },
+    {
+        "input": "/bus/5/send/MX8/lvl",
+        "output": "/bussend/5/8/mix_fader"
+    },
+    {
+        "input": "/bus/5/send/MX8/on",
+        "output": "/bussend/5/8/mix_on"
+    },
+    {
+        "input": "/bus/5/send/MX8/pre",
+        "output": "/bussend/5/8/pre"
+    },
+    {
+        "input": "/bus/6/col",
+        "output": "/bus/6/config_color"
+    },
+    {
+        "input": "/bus/6/fdr",
+        "output": "/bus/6/mix_fader"
+    },
+    {
+        "input": "/bus/6/main/1/lvl",
+        "output": "/busmainsend/6/1/mix_fader"
+    },
+    {
+        "input": "/bus/6/main/1/on",
+        "output": "/busmainsend/6/1/mix_on"
+    },
+    {
+        "input": "/bus/6/main/1/pre",
+        "output": "/busmainsend/6/1/pre"
+    },
+    {
+        "input": "/bus/6/main/2/lvl",
+        "output": "/busmainsend/6/2/mix_fader"
+    },
+    {
+        "input": "/bus/6/main/2/on",
+        "output": "/busmainsend/6/2/mix_on"
+    },
+    {
+        "input": "/bus/6/main/2/pre",
+        "output": "/busmainsend/6/2/pre"
+    },
+    {
+        "input": "/bus/6/main/3/lvl",
+        "output": "/busmainsend/6/3/mix_fader"
+    },
+    {
+        "input": "/bus/6/main/3/on",
+        "output": "/busmainsend/6/3/mix_on"
+    },
+    {
+        "input": "/bus/6/main/3/pre",
+        "output": "/busmainsend/6/3/pre"
+    },
+    {
+        "input": "/bus/6/main/4/lvl",
+        "output": "/busmainsend/6/4/mix_fader"
+    },
+    {
+        "input": "/bus/6/main/4/on",
+        "output": "/busmainsend/6/4/mix_on"
+    },
+    {
+        "input": "/bus/6/main/4/pre",
+        "output": "/busmainsend/6/4/pre"
+    },
+    {
+        "input": "/bus/6/mute",
+        "output": "/bus/6/mix_on"
+    },
+    {
+        "input": "/bus/6/name",
+        "output": "/bus/6/config_name"
+    },
+    {
+        "input": "/bus/6/send/1/lvl",
+        "output": "/busbussend/6/1/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/1/on",
+        "output": "/busbussend/6/1/mix_on"
+    },
+    {
+        "input": "/bus/6/send/1/pre",
+        "output": "/busbussend/6/1/pre"
+    },
+    {
+        "input": "/bus/6/send/10/lvl",
+        "output": "/busbussend/6/10/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/10/on",
+        "output": "/busbussend/6/10/mix_on"
+    },
+    {
+        "input": "/bus/6/send/10/pre",
+        "output": "/busbussend/6/10/pre"
+    },
+    {
+        "input": "/bus/6/send/11/lvl",
+        "output": "/busbussend/6/11/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/11/on",
+        "output": "/busbussend/6/11/mix_on"
+    },
+    {
+        "input": "/bus/6/send/11/pre",
+        "output": "/busbussend/6/11/pre"
+    },
+    {
+        "input": "/bus/6/send/12/lvl",
+        "output": "/busbussend/6/12/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/12/on",
+        "output": "/busbussend/6/12/mix_on"
+    },
+    {
+        "input": "/bus/6/send/12/pre",
+        "output": "/busbussend/6/12/pre"
+    },
+    {
+        "input": "/bus/6/send/13/lvl",
+        "output": "/busbussend/6/13/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/13/on",
+        "output": "/busbussend/6/13/mix_on"
+    },
+    {
+        "input": "/bus/6/send/13/pre",
+        "output": "/busbussend/6/13/pre"
+    },
+    {
+        "input": "/bus/6/send/14/lvl",
+        "output": "/busbussend/6/14/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/14/on",
+        "output": "/busbussend/6/14/mix_on"
+    },
+    {
+        "input": "/bus/6/send/14/pre",
+        "output": "/busbussend/6/14/pre"
+    },
+    {
+        "input": "/bus/6/send/15/lvl",
+        "output": "/busbussend/6/15/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/15/on",
+        "output": "/busbussend/6/15/mix_on"
+    },
+    {
+        "input": "/bus/6/send/15/pre",
+        "output": "/busbussend/6/15/pre"
+    },
+    {
+        "input": "/bus/6/send/16/lvl",
+        "output": "/busbussend/6/16/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/16/on",
+        "output": "/busbussend/6/16/mix_on"
+    },
+    {
+        "input": "/bus/6/send/16/pre",
+        "output": "/busbussend/6/16/pre"
+    },
+    {
+        "input": "/bus/6/send/2/lvl",
+        "output": "/busbussend/6/2/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/2/on",
+        "output": "/busbussend/6/2/mix_on"
+    },
+    {
+        "input": "/bus/6/send/2/pre",
+        "output": "/busbussend/6/2/pre"
+    },
+    {
+        "input": "/bus/6/send/3/lvl",
+        "output": "/busbussend/6/3/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/3/on",
+        "output": "/busbussend/6/3/mix_on"
+    },
+    {
+        "input": "/bus/6/send/3/pre",
+        "output": "/busbussend/6/3/pre"
+    },
+    {
+        "input": "/bus/6/send/4/lvl",
+        "output": "/busbussend/6/4/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/4/on",
+        "output": "/busbussend/6/4/mix_on"
+    },
+    {
+        "input": "/bus/6/send/4/pre",
+        "output": "/busbussend/6/4/pre"
+    },
+    {
+        "input": "/bus/6/send/5/lvl",
+        "output": "/busbussend/6/5/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/5/on",
+        "output": "/busbussend/6/5/mix_on"
+    },
+    {
+        "input": "/bus/6/send/5/pre",
+        "output": "/busbussend/6/5/pre"
+    },
+    {
+        "input": "/bus/6/send/7/lvl",
+        "output": "/busbussend/6/7/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/7/on",
+        "output": "/busbussend/6/7/mix_on"
+    },
+    {
+        "input": "/bus/6/send/7/pre",
+        "output": "/busbussend/6/7/pre"
+    },
+    {
+        "input": "/bus/6/send/8/lvl",
+        "output": "/busbussend/6/8/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/8/on",
+        "output": "/busbussend/6/8/mix_on"
+    },
+    {
+        "input": "/bus/6/send/8/pre",
+        "output": "/busbussend/6/8/pre"
+    },
+    {
+        "input": "/bus/6/send/9/lvl",
+        "output": "/busbussend/6/9/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/9/on",
+        "output": "/busbussend/6/9/mix_on"
+    },
+    {
+        "input": "/bus/6/send/9/pre",
+        "output": "/busbussend/6/9/pre"
+    },
+    {
+        "input": "/bus/6/send/MX1/lvl",
+        "output": "/bussend/6/1/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/MX1/on",
+        "output": "/bussend/6/1/mix_on"
+    },
+    {
+        "input": "/bus/6/send/MX1/pre",
+        "output": "/bussend/6/1/pre"
+    },
+    {
+        "input": "/bus/6/send/MX2/lvl",
+        "output": "/bussend/6/2/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/MX2/on",
+        "output": "/bussend/6/2/mix_on"
+    },
+    {
+        "input": "/bus/6/send/MX2/pre",
+        "output": "/bussend/6/2/pre"
+    },
+    {
+        "input": "/bus/6/send/MX3/lvl",
+        "output": "/bussend/6/3/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/MX3/on",
+        "output": "/bussend/6/3/mix_on"
+    },
+    {
+        "input": "/bus/6/send/MX3/pre",
+        "output": "/bussend/6/3/pre"
+    },
+    {
+        "input": "/bus/6/send/MX4/lvl",
+        "output": "/bussend/6/4/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/MX4/on",
+        "output": "/bussend/6/4/mix_on"
+    },
+    {
+        "input": "/bus/6/send/MX4/pre",
+        "output": "/bussend/6/4/pre"
+    },
+    {
+        "input": "/bus/6/send/MX5/lvl",
+        "output": "/bussend/6/5/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/MX5/on",
+        "output": "/bussend/6/5/mix_on"
+    },
+    {
+        "input": "/bus/6/send/MX5/pre",
+        "output": "/bussend/6/5/pre"
+    },
+    {
+        "input": "/bus/6/send/MX6/lvl",
+        "output": "/bussend/6/6/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/MX6/on",
+        "output": "/bussend/6/6/mix_on"
+    },
+    {
+        "input": "/bus/6/send/MX6/pre",
+        "output": "/bussend/6/6/pre"
+    },
+    {
+        "input": "/bus/6/send/MX7/lvl",
+        "output": "/bussend/6/7/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/MX7/on",
+        "output": "/bussend/6/7/mix_on"
+    },
+    {
+        "input": "/bus/6/send/MX7/pre",
+        "output": "/bussend/6/7/pre"
+    },
+    {
+        "input": "/bus/6/send/MX8/lvl",
+        "output": "/bussend/6/8/mix_fader"
+    },
+    {
+        "input": "/bus/6/send/MX8/on",
+        "output": "/bussend/6/8/mix_on"
+    },
+    {
+        "input": "/bus/6/send/MX8/pre",
+        "output": "/bussend/6/8/pre"
+    },
+    {
+        "input": "/bus/7/col",
+        "output": "/bus/7/config_color"
+    },
+    {
+        "input": "/bus/7/fdr",
+        "output": "/bus/7/mix_fader"
+    },
+    {
+        "input": "/bus/7/main/1/lvl",
+        "output": "/busmainsend/7/1/mix_fader"
+    },
+    {
+        "input": "/bus/7/main/1/on",
+        "output": "/busmainsend/7/1/mix_on"
+    },
+    {
+        "input": "/bus/7/main/1/pre",
+        "output": "/busmainsend/7/1/pre"
+    },
+    {
+        "input": "/bus/7/main/2/lvl",
+        "output": "/busmainsend/7/2/mix_fader"
+    },
+    {
+        "input": "/bus/7/main/2/on",
+        "output": "/busmainsend/7/2/mix_on"
+    },
+    {
+        "input": "/bus/7/main/2/pre",
+        "output": "/busmainsend/7/2/pre"
+    },
+    {
+        "input": "/bus/7/main/3/lvl",
+        "output": "/busmainsend/7/3/mix_fader"
+    },
+    {
+        "input": "/bus/7/main/3/on",
+        "output": "/busmainsend/7/3/mix_on"
+    },
+    {
+        "input": "/bus/7/main/3/pre",
+        "output": "/busmainsend/7/3/pre"
+    },
+    {
+        "input": "/bus/7/main/4/lvl",
+        "output": "/busmainsend/7/4/mix_fader"
+    },
+    {
+        "input": "/bus/7/main/4/on",
+        "output": "/busmainsend/7/4/mix_on"
+    },
+    {
+        "input": "/bus/7/main/4/pre",
+        "output": "/busmainsend/7/4/pre"
+    },
+    {
+        "input": "/bus/7/mute",
+        "output": "/bus/7/mix_on"
+    },
+    {
+        "input": "/bus/7/name",
+        "output": "/bus/7/config_name"
+    },
+    {
+        "input": "/bus/7/send/1/lvl",
+        "output": "/busbussend/7/1/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/1/on",
+        "output": "/busbussend/7/1/mix_on"
+    },
+    {
+        "input": "/bus/7/send/1/pre",
+        "output": "/busbussend/7/1/pre"
+    },
+    {
+        "input": "/bus/7/send/10/lvl",
+        "output": "/busbussend/7/10/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/10/on",
+        "output": "/busbussend/7/10/mix_on"
+    },
+    {
+        "input": "/bus/7/send/10/pre",
+        "output": "/busbussend/7/10/pre"
+    },
+    {
+        "input": "/bus/7/send/11/lvl",
+        "output": "/busbussend/7/11/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/11/on",
+        "output": "/busbussend/7/11/mix_on"
+    },
+    {
+        "input": "/bus/7/send/11/pre",
+        "output": "/busbussend/7/11/pre"
+    },
+    {
+        "input": "/bus/7/send/12/lvl",
+        "output": "/busbussend/7/12/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/12/on",
+        "output": "/busbussend/7/12/mix_on"
+    },
+    {
+        "input": "/bus/7/send/12/pre",
+        "output": "/busbussend/7/12/pre"
+    },
+    {
+        "input": "/bus/7/send/13/lvl",
+        "output": "/busbussend/7/13/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/13/on",
+        "output": "/busbussend/7/13/mix_on"
+    },
+    {
+        "input": "/bus/7/send/13/pre",
+        "output": "/busbussend/7/13/pre"
+    },
+    {
+        "input": "/bus/7/send/14/lvl",
+        "output": "/busbussend/7/14/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/14/on",
+        "output": "/busbussend/7/14/mix_on"
+    },
+    {
+        "input": "/bus/7/send/14/pre",
+        "output": "/busbussend/7/14/pre"
+    },
+    {
+        "input": "/bus/7/send/15/lvl",
+        "output": "/busbussend/7/15/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/15/on",
+        "output": "/busbussend/7/15/mix_on"
+    },
+    {
+        "input": "/bus/7/send/15/pre",
+        "output": "/busbussend/7/15/pre"
+    },
+    {
+        "input": "/bus/7/send/16/lvl",
+        "output": "/busbussend/7/16/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/16/on",
+        "output": "/busbussend/7/16/mix_on"
+    },
+    {
+        "input": "/bus/7/send/16/pre",
+        "output": "/busbussend/7/16/pre"
+    },
+    {
+        "input": "/bus/7/send/2/lvl",
+        "output": "/busbussend/7/2/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/2/on",
+        "output": "/busbussend/7/2/mix_on"
+    },
+    {
+        "input": "/bus/7/send/2/pre",
+        "output": "/busbussend/7/2/pre"
+    },
+    {
+        "input": "/bus/7/send/3/lvl",
+        "output": "/busbussend/7/3/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/3/on",
+        "output": "/busbussend/7/3/mix_on"
+    },
+    {
+        "input": "/bus/7/send/3/pre",
+        "output": "/busbussend/7/3/pre"
+    },
+    {
+        "input": "/bus/7/send/4/lvl",
+        "output": "/busbussend/7/4/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/4/on",
+        "output": "/busbussend/7/4/mix_on"
+    },
+    {
+        "input": "/bus/7/send/4/pre",
+        "output": "/busbussend/7/4/pre"
+    },
+    {
+        "input": "/bus/7/send/5/lvl",
+        "output": "/busbussend/7/5/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/5/on",
+        "output": "/busbussend/7/5/mix_on"
+    },
+    {
+        "input": "/bus/7/send/5/pre",
+        "output": "/busbussend/7/5/pre"
+    },
+    {
+        "input": "/bus/7/send/6/lvl",
+        "output": "/busbussend/7/6/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/6/on",
+        "output": "/busbussend/7/6/mix_on"
+    },
+    {
+        "input": "/bus/7/send/6/pre",
+        "output": "/busbussend/7/6/pre"
+    },
+    {
+        "input": "/bus/7/send/8/lvl",
+        "output": "/busbussend/7/8/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/8/on",
+        "output": "/busbussend/7/8/mix_on"
+    },
+    {
+        "input": "/bus/7/send/8/pre",
+        "output": "/busbussend/7/8/pre"
+    },
+    {
+        "input": "/bus/7/send/9/lvl",
+        "output": "/busbussend/7/9/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/9/on",
+        "output": "/busbussend/7/9/mix_on"
+    },
+    {
+        "input": "/bus/7/send/9/pre",
+        "output": "/busbussend/7/9/pre"
+    },
+    {
+        "input": "/bus/7/send/MX1/lvl",
+        "output": "/bussend/7/1/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/MX1/on",
+        "output": "/bussend/7/1/mix_on"
+    },
+    {
+        "input": "/bus/7/send/MX1/pre",
+        "output": "/bussend/7/1/pre"
+    },
+    {
+        "input": "/bus/7/send/MX2/lvl",
+        "output": "/bussend/7/2/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/MX2/on",
+        "output": "/bussend/7/2/mix_on"
+    },
+    {
+        "input": "/bus/7/send/MX2/pre",
+        "output": "/bussend/7/2/pre"
+    },
+    {
+        "input": "/bus/7/send/MX3/lvl",
+        "output": "/bussend/7/3/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/MX3/on",
+        "output": "/bussend/7/3/mix_on"
+    },
+    {
+        "input": "/bus/7/send/MX3/pre",
+        "output": "/bussend/7/3/pre"
+    },
+    {
+        "input": "/bus/7/send/MX4/lvl",
+        "output": "/bussend/7/4/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/MX4/on",
+        "output": "/bussend/7/4/mix_on"
+    },
+    {
+        "input": "/bus/7/send/MX4/pre",
+        "output": "/bussend/7/4/pre"
+    },
+    {
+        "input": "/bus/7/send/MX5/lvl",
+        "output": "/bussend/7/5/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/MX5/on",
+        "output": "/bussend/7/5/mix_on"
+    },
+    {
+        "input": "/bus/7/send/MX5/pre",
+        "output": "/bussend/7/5/pre"
+    },
+    {
+        "input": "/bus/7/send/MX6/lvl",
+        "output": "/bussend/7/6/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/MX6/on",
+        "output": "/bussend/7/6/mix_on"
+    },
+    {
+        "input": "/bus/7/send/MX6/pre",
+        "output": "/bussend/7/6/pre"
+    },
+    {
+        "input": "/bus/7/send/MX7/lvl",
+        "output": "/bussend/7/7/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/MX7/on",
+        "output": "/bussend/7/7/mix_on"
+    },
+    {
+        "input": "/bus/7/send/MX7/pre",
+        "output": "/bussend/7/7/pre"
+    },
+    {
+        "input": "/bus/7/send/MX8/lvl",
+        "output": "/bussend/7/8/mix_fader"
+    },
+    {
+        "input": "/bus/7/send/MX8/on",
+        "output": "/bussend/7/8/mix_on"
+    },
+    {
+        "input": "/bus/7/send/MX8/pre",
+        "output": "/bussend/7/8/pre"
+    },
+    {
+        "input": "/bus/8/col",
+        "output": "/bus/8/config_color"
+    },
+    {
+        "input": "/bus/8/fdr",
+        "output": "/bus/8/mix_fader"
+    },
+    {
+        "input": "/bus/8/main/1/lvl",
+        "output": "/busmainsend/8/1/mix_fader"
+    },
+    {
+        "input": "/bus/8/main/1/on",
+        "output": "/busmainsend/8/1/mix_on"
+    },
+    {
+        "input": "/bus/8/main/1/pre",
+        "output": "/busmainsend/8/1/pre"
+    },
+    {
+        "input": "/bus/8/main/2/lvl",
+        "output": "/busmainsend/8/2/mix_fader"
+    },
+    {
+        "input": "/bus/8/main/2/on",
+        "output": "/busmainsend/8/2/mix_on"
+    },
+    {
+        "input": "/bus/8/main/2/pre",
+        "output": "/busmainsend/8/2/pre"
+    },
+    {
+        "input": "/bus/8/main/3/lvl",
+        "output": "/busmainsend/8/3/mix_fader"
+    },
+    {
+        "input": "/bus/8/main/3/on",
+        "output": "/busmainsend/8/3/mix_on"
+    },
+    {
+        "input": "/bus/8/main/3/pre",
+        "output": "/busmainsend/8/3/pre"
+    },
+    {
+        "input": "/bus/8/main/4/lvl",
+        "output": "/busmainsend/8/4/mix_fader"
+    },
+    {
+        "input": "/bus/8/main/4/on",
+        "output": "/busmainsend/8/4/mix_on"
+    },
+    {
+        "input": "/bus/8/main/4/pre",
+        "output": "/busmainsend/8/4/pre"
+    },
+    {
+        "input": "/bus/8/mute",
+        "output": "/bus/8/mix_on"
+    },
+    {
+        "input": "/bus/8/name",
+        "output": "/bus/8/config_name"
+    },
+    {
+        "input": "/bus/8/send/1/lvl",
+        "output": "/busbussend/8/1/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/1/on",
+        "output": "/busbussend/8/1/mix_on"
+    },
+    {
+        "input": "/bus/8/send/1/pre",
+        "output": "/busbussend/8/1/pre"
+    },
+    {
+        "input": "/bus/8/send/10/lvl",
+        "output": "/busbussend/8/10/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/10/on",
+        "output": "/busbussend/8/10/mix_on"
+    },
+    {
+        "input": "/bus/8/send/10/pre",
+        "output": "/busbussend/8/10/pre"
+    },
+    {
+        "input": "/bus/8/send/11/lvl",
+        "output": "/busbussend/8/11/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/11/on",
+        "output": "/busbussend/8/11/mix_on"
+    },
+    {
+        "input": "/bus/8/send/11/pre",
+        "output": "/busbussend/8/11/pre"
+    },
+    {
+        "input": "/bus/8/send/12/lvl",
+        "output": "/busbussend/8/12/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/12/on",
+        "output": "/busbussend/8/12/mix_on"
+    },
+    {
+        "input": "/bus/8/send/12/pre",
+        "output": "/busbussend/8/12/pre"
+    },
+    {
+        "input": "/bus/8/send/13/lvl",
+        "output": "/busbussend/8/13/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/13/on",
+        "output": "/busbussend/8/13/mix_on"
+    },
+    {
+        "input": "/bus/8/send/13/pre",
+        "output": "/busbussend/8/13/pre"
+    },
+    {
+        "input": "/bus/8/send/14/lvl",
+        "output": "/busbussend/8/14/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/14/on",
+        "output": "/busbussend/8/14/mix_on"
+    },
+    {
+        "input": "/bus/8/send/14/pre",
+        "output": "/busbussend/8/14/pre"
+    },
+    {
+        "input": "/bus/8/send/15/lvl",
+        "output": "/busbussend/8/15/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/15/on",
+        "output": "/busbussend/8/15/mix_on"
+    },
+    {
+        "input": "/bus/8/send/15/pre",
+        "output": "/busbussend/8/15/pre"
+    },
+    {
+        "input": "/bus/8/send/16/lvl",
+        "output": "/busbussend/8/16/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/16/on",
+        "output": "/busbussend/8/16/mix_on"
+    },
+    {
+        "input": "/bus/8/send/16/pre",
+        "output": "/busbussend/8/16/pre"
+    },
+    {
+        "input": "/bus/8/send/2/lvl",
+        "output": "/busbussend/8/2/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/2/on",
+        "output": "/busbussend/8/2/mix_on"
+    },
+    {
+        "input": "/bus/8/send/2/pre",
+        "output": "/busbussend/8/2/pre"
+    },
+    {
+        "input": "/bus/8/send/3/lvl",
+        "output": "/busbussend/8/3/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/3/on",
+        "output": "/busbussend/8/3/mix_on"
+    },
+    {
+        "input": "/bus/8/send/3/pre",
+        "output": "/busbussend/8/3/pre"
+    },
+    {
+        "input": "/bus/8/send/4/lvl",
+        "output": "/busbussend/8/4/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/4/on",
+        "output": "/busbussend/8/4/mix_on"
+    },
+    {
+        "input": "/bus/8/send/4/pre",
+        "output": "/busbussend/8/4/pre"
+    },
+    {
+        "input": "/bus/8/send/5/lvl",
+        "output": "/busbussend/8/5/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/5/on",
+        "output": "/busbussend/8/5/mix_on"
+    },
+    {
+        "input": "/bus/8/send/5/pre",
+        "output": "/busbussend/8/5/pre"
+    },
+    {
+        "input": "/bus/8/send/6/lvl",
+        "output": "/busbussend/8/6/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/6/on",
+        "output": "/busbussend/8/6/mix_on"
+    },
+    {
+        "input": "/bus/8/send/6/pre",
+        "output": "/busbussend/8/6/pre"
+    },
+    {
+        "input": "/bus/8/send/7/lvl",
+        "output": "/busbussend/8/7/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/7/on",
+        "output": "/busbussend/8/7/mix_on"
+    },
+    {
+        "input": "/bus/8/send/7/pre",
+        "output": "/busbussend/8/7/pre"
+    },
+    {
+        "input": "/bus/8/send/9/lvl",
+        "output": "/busbussend/8/9/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/9/on",
+        "output": "/busbussend/8/9/mix_on"
+    },
+    {
+        "input": "/bus/8/send/9/pre",
+        "output": "/busbussend/8/9/pre"
+    },
+    {
+        "input": "/bus/8/send/MX1/lvl",
+        "output": "/bussend/8/1/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/MX1/on",
+        "output": "/bussend/8/1/mix_on"
+    },
+    {
+        "input": "/bus/8/send/MX1/pre",
+        "output": "/bussend/8/1/pre"
+    },
+    {
+        "input": "/bus/8/send/MX2/lvl",
+        "output": "/bussend/8/2/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/MX2/on",
+        "output": "/bussend/8/2/mix_on"
+    },
+    {
+        "input": "/bus/8/send/MX2/pre",
+        "output": "/bussend/8/2/pre"
+    },
+    {
+        "input": "/bus/8/send/MX3/lvl",
+        "output": "/bussend/8/3/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/MX3/on",
+        "output": "/bussend/8/3/mix_on"
+    },
+    {
+        "input": "/bus/8/send/MX3/pre",
+        "output": "/bussend/8/3/pre"
+    },
+    {
+        "input": "/bus/8/send/MX4/lvl",
+        "output": "/bussend/8/4/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/MX4/on",
+        "output": "/bussend/8/4/mix_on"
+    },
+    {
+        "input": "/bus/8/send/MX4/pre",
+        "output": "/bussend/8/4/pre"
+    },
+    {
+        "input": "/bus/8/send/MX5/lvl",
+        "output": "/bussend/8/5/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/MX5/on",
+        "output": "/bussend/8/5/mix_on"
+    },
+    {
+        "input": "/bus/8/send/MX5/pre",
+        "output": "/bussend/8/5/pre"
+    },
+    {
+        "input": "/bus/8/send/MX6/lvl",
+        "output": "/bussend/8/6/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/MX6/on",
+        "output": "/bussend/8/6/mix_on"
+    },
+    {
+        "input": "/bus/8/send/MX6/pre",
+        "output": "/bussend/8/6/pre"
+    },
+    {
+        "input": "/bus/8/send/MX7/lvl",
+        "output": "/bussend/8/7/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/MX7/on",
+        "output": "/bussend/8/7/mix_on"
+    },
+    {
+        "input": "/bus/8/send/MX7/pre",
+        "output": "/bussend/8/7/pre"
+    },
+    {
+        "input": "/bus/8/send/MX8/lvl",
+        "output": "/bussend/8/8/mix_fader"
+    },
+    {
+        "input": "/bus/8/send/MX8/on",
+        "output": "/bussend/8/8/mix_on"
+    },
+    {
+        "input": "/bus/8/send/MX8/pre",
+        "output": "/bussend/8/8/pre"
+    },
+    {
+        "input": "/bus/9/col",
+        "output": "/bus/9/config_color"
+    },
+    {
+        "input": "/bus/9/fdr",
+        "output": "/bus/9/mix_fader"
+    },
+    {
+        "input": "/bus/9/main/1/lvl",
+        "output": "/busmainsend/9/1/mix_fader"
+    },
+    {
+        "input": "/bus/9/main/1/on",
+        "output": "/busmainsend/9/1/mix_on"
+    },
+    {
+        "input": "/bus/9/main/1/pre",
+        "output": "/busmainsend/9/1/pre"
+    },
+    {
+        "input": "/bus/9/main/2/lvl",
+        "output": "/busmainsend/9/2/mix_fader"
+    },
+    {
+        "input": "/bus/9/main/2/on",
+        "output": "/busmainsend/9/2/mix_on"
+    },
+    {
+        "input": "/bus/9/main/2/pre",
+        "output": "/busmainsend/9/2/pre"
+    },
+    {
+        "input": "/bus/9/main/3/lvl",
+        "output": "/busmainsend/9/3/mix_fader"
+    },
+    {
+        "input": "/bus/9/main/3/on",
+        "output": "/busmainsend/9/3/mix_on"
+    },
+    {
+        "input": "/bus/9/main/3/pre",
+        "output": "/busmainsend/9/3/pre"
+    },
+    {
+        "input": "/bus/9/main/4/lvl",
+        "output": "/busmainsend/9/4/mix_fader"
+    },
+    {
+        "input": "/bus/9/main/4/on",
+        "output": "/busmainsend/9/4/mix_on"
+    },
+    {
+        "input": "/bus/9/main/4/pre",
+        "output": "/busmainsend/9/4/pre"
+    },
+    {
+        "input": "/bus/9/mute",
+        "output": "/bus/9/mix_on"
+    },
+    {
+        "input": "/bus/9/name",
+        "output": "/bus/9/config_name"
+    },
+    {
+        "input": "/bus/9/send/1/lvl",
+        "output": "/busbussend/9/1/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/1/on",
+        "output": "/busbussend/9/1/mix_on"
+    },
+    {
+        "input": "/bus/9/send/1/pre",
+        "output": "/busbussend/9/1/pre"
+    },
+    {
+        "input": "/bus/9/send/10/lvl",
+        "output": "/busbussend/9/10/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/10/on",
+        "output": "/busbussend/9/10/mix_on"
+    },
+    {
+        "input": "/bus/9/send/10/pre",
+        "output": "/busbussend/9/10/pre"
+    },
+    {
+        "input": "/bus/9/send/11/lvl",
+        "output": "/busbussend/9/11/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/11/on",
+        "output": "/busbussend/9/11/mix_on"
+    },
+    {
+        "input": "/bus/9/send/11/pre",
+        "output": "/busbussend/9/11/pre"
+    },
+    {
+        "input": "/bus/9/send/12/lvl",
+        "output": "/busbussend/9/12/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/12/on",
+        "output": "/busbussend/9/12/mix_on"
+    },
+    {
+        "input": "/bus/9/send/12/pre",
+        "output": "/busbussend/9/12/pre"
+    },
+    {
+        "input": "/bus/9/send/13/lvl",
+        "output": "/busbussend/9/13/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/13/on",
+        "output": "/busbussend/9/13/mix_on"
+    },
+    {
+        "input": "/bus/9/send/13/pre",
+        "output": "/busbussend/9/13/pre"
+    },
+    {
+        "input": "/bus/9/send/14/lvl",
+        "output": "/busbussend/9/14/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/14/on",
+        "output": "/busbussend/9/14/mix_on"
+    },
+    {
+        "input": "/bus/9/send/14/pre",
+        "output": "/busbussend/9/14/pre"
+    },
+    {
+        "input": "/bus/9/send/15/lvl",
+        "output": "/busbussend/9/15/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/15/on",
+        "output": "/busbussend/9/15/mix_on"
+    },
+    {
+        "input": "/bus/9/send/15/pre",
+        "output": "/busbussend/9/15/pre"
+    },
+    {
+        "input": "/bus/9/send/16/lvl",
+        "output": "/busbussend/9/16/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/16/on",
+        "output": "/busbussend/9/16/mix_on"
+    },
+    {
+        "input": "/bus/9/send/16/pre",
+        "output": "/busbussend/9/16/pre"
+    },
+    {
+        "input": "/bus/9/send/2/lvl",
+        "output": "/busbussend/9/2/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/2/on",
+        "output": "/busbussend/9/2/mix_on"
+    },
+    {
+        "input": "/bus/9/send/2/pre",
+        "output": "/busbussend/9/2/pre"
+    },
+    {
+        "input": "/bus/9/send/3/lvl",
+        "output": "/busbussend/9/3/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/3/on",
+        "output": "/busbussend/9/3/mix_on"
+    },
+    {
+        "input": "/bus/9/send/3/pre",
+        "output": "/busbussend/9/3/pre"
+    },
+    {
+        "input": "/bus/9/send/4/lvl",
+        "output": "/busbussend/9/4/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/4/on",
+        "output": "/busbussend/9/4/mix_on"
+    },
+    {
+        "input": "/bus/9/send/4/pre",
+        "output": "/busbussend/9/4/pre"
+    },
+    {
+        "input": "/bus/9/send/5/lvl",
+        "output": "/busbussend/9/5/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/5/on",
+        "output": "/busbussend/9/5/mix_on"
+    },
+    {
+        "input": "/bus/9/send/5/pre",
+        "output": "/busbussend/9/5/pre"
+    },
+    {
+        "input": "/bus/9/send/6/lvl",
+        "output": "/busbussend/9/6/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/6/on",
+        "output": "/busbussend/9/6/mix_on"
+    },
+    {
+        "input": "/bus/9/send/6/pre",
+        "output": "/busbussend/9/6/pre"
+    },
+    {
+        "input": "/bus/9/send/7/lvl",
+        "output": "/busbussend/9/7/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/7/on",
+        "output": "/busbussend/9/7/mix_on"
+    },
+    {
+        "input": "/bus/9/send/7/pre",
+        "output": "/busbussend/9/7/pre"
+    },
+    {
+        "input": "/bus/9/send/8/lvl",
+        "output": "/busbussend/9/8/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/8/on",
+        "output": "/busbussend/9/8/mix_on"
+    },
+    {
+        "input": "/bus/9/send/8/pre",
+        "output": "/busbussend/9/8/pre"
+    },
+    {
+        "input": "/bus/9/send/MX1/lvl",
+        "output": "/bussend/9/1/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/MX1/on",
+        "output": "/bussend/9/1/mix_on"
+    },
+    {
+        "input": "/bus/9/send/MX1/pre",
+        "output": "/bussend/9/1/pre"
+    },
+    {
+        "input": "/bus/9/send/MX2/lvl",
+        "output": "/bussend/9/2/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/MX2/on",
+        "output": "/bussend/9/2/mix_on"
+    },
+    {
+        "input": "/bus/9/send/MX2/pre",
+        "output": "/bussend/9/2/pre"
+    },
+    {
+        "input": "/bus/9/send/MX3/lvl",
+        "output": "/bussend/9/3/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/MX3/on",
+        "output": "/bussend/9/3/mix_on"
+    },
+    {
+        "input": "/bus/9/send/MX3/pre",
+        "output": "/bussend/9/3/pre"
+    },
+    {
+        "input": "/bus/9/send/MX4/lvl",
+        "output": "/bussend/9/4/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/MX4/on",
+        "output": "/bussend/9/4/mix_on"
+    },
+    {
+        "input": "/bus/9/send/MX4/pre",
+        "output": "/bussend/9/4/pre"
+    },
+    {
+        "input": "/bus/9/send/MX5/lvl",
+        "output": "/bussend/9/5/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/MX5/on",
+        "output": "/bussend/9/5/mix_on"
+    },
+    {
+        "input": "/bus/9/send/MX5/pre",
+        "output": "/bussend/9/5/pre"
+    },
+    {
+        "input": "/bus/9/send/MX6/lvl",
+        "output": "/bussend/9/6/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/MX6/on",
+        "output": "/bussend/9/6/mix_on"
+    },
+    {
+        "input": "/bus/9/send/MX6/pre",
+        "output": "/bussend/9/6/pre"
+    },
+    {
+        "input": "/bus/9/send/MX7/lvl",
+        "output": "/bussend/9/7/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/MX7/on",
+        "output": "/bussend/9/7/mix_on"
+    },
+    {
+        "input": "/bus/9/send/MX7/pre",
+        "output": "/bussend/9/7/pre"
+    },
+    {
+        "input": "/bus/9/send/MX8/lvl",
+        "output": "/bussend/9/8/mix_fader"
+    },
+    {
+        "input": "/bus/9/send/MX8/on",
+        "output": "/bussend/9/8/mix_on"
+    },
+    {
+        "input": "/bus/9/send/MX8/pre",
+        "output": "/bussend/9/8/pre"
+    },
+    {
+        "input": "/ch/1/col",
+        "output": "/ch/1/config_color"
+    },
+    {
+        "input": "/ch/1/fdr",
+        "output": "/ch/1/mix_fader"
+    },
+    {
+        "input": "/ch/1/in/conn/altgrp",
+        "output": "/ch/1/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/1/in/conn/altin",
+        "output": "/ch/1/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/1/in/conn/grp",
+        "output": "/ch/1/input_conn_grp"
+    },
+    {
+        "input": "/ch/1/in/conn/in",
+        "output": "/ch/1/input_conn_in"
+    },
+    {
+        "input": "/ch/1/in/set/$g",
+        "output": "/ch/1/preamp_gain"
+    },
+    {
+        "input": "/ch/1/in/set/$mode",
+        "output": "/ch/1/input_mode"
+    },
+    {
+        "input": "/ch/1/in/set/$vph",
+        "output": "/ch/1/preamp_phantom"
+    },
+    {
+        "input": "/ch/1/in/set/altsrc",
+        "output": "/ch/1/input_altsrc"
+    },
+    {
+        "input": "/ch/1/in/set/bal",
+        "output": "/ch/1/input_balance"
+    },
+    {
+        "input": "/ch/1/in/set/dly",
+        "output": "/ch/1/input_delay"
+    },
+    {
+        "input": "/ch/1/in/set/dlymode",
+        "output": "/ch/1/input_delay_mode"
+    },
+    {
+        "input": "/ch/1/in/set/dlyon",
+        "output": "/ch/1/input_delay_on"
+    },
+    {
+        "input": "/ch/1/in/set/inv",
+        "output": "/ch/1/input_invert"
+    },
+    {
+        "input": "/ch/1/in/set/srcauto",
+        "output": "/ch/1/input_srcauto"
+    },
+    {
+        "input": "/ch/1/in/set/trim",
+        "output": "/ch/1/input_trim"
+    },
+    {
+        "input": "/ch/1/mute",
+        "output": "/ch/1/mix_on"
+    },
+    {
+        "input": "/ch/1/name",
+        "output": "/ch/1/config_name"
+    },
+    {
+        "input": "/ch/1/send/1/lvl",
+        "output": "/chsend/1/1/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/1/on",
+        "output": "/chsend/1/1/mix_on"
+    },
+    {
+        "input": "/ch/1/send/10/lvl",
+        "output": "/chsend/1/10/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/10/on",
+        "output": "/chsend/1/10/mix_on"
+    },
+    {
+        "input": "/ch/1/send/11/lvl",
+        "output": "/chsend/1/11/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/11/on",
+        "output": "/chsend/1/11/mix_on"
+    },
+    {
+        "input": "/ch/1/send/12/lvl",
+        "output": "/chsend/1/12/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/12/on",
+        "output": "/chsend/1/12/mix_on"
+    },
+    {
+        "input": "/ch/1/send/13/lvl",
+        "output": "/chsend/1/13/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/13/on",
+        "output": "/chsend/1/13/mix_on"
+    },
+    {
+        "input": "/ch/1/send/14/lvl",
+        "output": "/chsend/1/14/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/14/on",
+        "output": "/chsend/1/14/mix_on"
+    },
+    {
+        "input": "/ch/1/send/15/lvl",
+        "output": "/chsend/1/15/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/15/on",
+        "output": "/chsend/1/15/mix_on"
+    },
+    {
+        "input": "/ch/1/send/16/lvl",
+        "output": "/chsend/1/16/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/16/on",
+        "output": "/chsend/1/16/mix_on"
+    },
+    {
+        "input": "/ch/1/send/2/lvl",
+        "output": "/chsend/1/2/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/2/on",
+        "output": "/chsend/1/2/mix_on"
+    },
+    {
+        "input": "/ch/1/send/3/lvl",
+        "output": "/chsend/1/3/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/3/on",
+        "output": "/chsend/1/3/mix_on"
+    },
+    {
+        "input": "/ch/1/send/4/lvl",
+        "output": "/chsend/1/4/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/4/on",
+        "output": "/chsend/1/4/mix_on"
+    },
+    {
+        "input": "/ch/1/send/5/lvl",
+        "output": "/chsend/1/5/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/5/on",
+        "output": "/chsend/1/5/mix_on"
+    },
+    {
+        "input": "/ch/1/send/6/lvl",
+        "output": "/chsend/1/6/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/6/on",
+        "output": "/chsend/1/6/mix_on"
+    },
+    {
+        "input": "/ch/1/send/7/lvl",
+        "output": "/chsend/1/7/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/7/on",
+        "output": "/chsend/1/7/mix_on"
+    },
+    {
+        "input": "/ch/1/send/8/lvl",
+        "output": "/chsend/1/8/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/8/on",
+        "output": "/chsend/1/8/mix_on"
+    },
+    {
+        "input": "/ch/1/send/9/lvl",
+        "output": "/chsend/1/9/mix_fader"
+    },
+    {
+        "input": "/ch/1/send/9/on",
+        "output": "/chsend/1/9/mix_on"
+    },
+    {
+        "input": "/ch/10/col",
+        "output": "/ch/10/config_color"
+    },
+    {
+        "input": "/ch/10/fdr",
+        "output": "/ch/10/mix_fader"
+    },
+    {
+        "input": "/ch/10/in/conn/altgrp",
+        "output": "/ch/10/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/10/in/conn/altin",
+        "output": "/ch/10/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/10/in/conn/grp",
+        "output": "/ch/10/input_conn_grp"
+    },
+    {
+        "input": "/ch/10/in/conn/in",
+        "output": "/ch/10/input_conn_in"
+    },
+    {
+        "input": "/ch/10/in/set/$g",
+        "output": "/ch/10/preamp_gain"
+    },
+    {
+        "input": "/ch/10/in/set/$mode",
+        "output": "/ch/10/input_mode"
+    },
+    {
+        "input": "/ch/10/in/set/$vph",
+        "output": "/ch/10/preamp_phantom"
+    },
+    {
+        "input": "/ch/10/in/set/altsrc",
+        "output": "/ch/10/input_altsrc"
+    },
+    {
+        "input": "/ch/10/in/set/bal",
+        "output": "/ch/10/input_balance"
+    },
+    {
+        "input": "/ch/10/in/set/dly",
+        "output": "/ch/10/input_delay"
+    },
+    {
+        "input": "/ch/10/in/set/dlymode",
+        "output": "/ch/10/input_delay_mode"
+    },
+    {
+        "input": "/ch/10/in/set/dlyon",
+        "output": "/ch/10/input_delay_on"
+    },
+    {
+        "input": "/ch/10/in/set/inv",
+        "output": "/ch/10/input_invert"
+    },
+    {
+        "input": "/ch/10/in/set/srcauto",
+        "output": "/ch/10/input_srcauto"
+    },
+    {
+        "input": "/ch/10/in/set/trim",
+        "output": "/ch/10/input_trim"
+    },
+    {
+        "input": "/ch/10/mute",
+        "output": "/ch/10/mix_on"
+    },
+    {
+        "input": "/ch/10/name",
+        "output": "/ch/10/config_name"
+    },
+    {
+        "input": "/ch/10/send/1/lvl",
+        "output": "/chsend/10/1/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/1/on",
+        "output": "/chsend/10/1/mix_on"
+    },
+    {
+        "input": "/ch/10/send/10/lvl",
+        "output": "/chsend/10/10/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/10/on",
+        "output": "/chsend/10/10/mix_on"
+    },
+    {
+        "input": "/ch/10/send/11/lvl",
+        "output": "/chsend/10/11/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/11/on",
+        "output": "/chsend/10/11/mix_on"
+    },
+    {
+        "input": "/ch/10/send/12/lvl",
+        "output": "/chsend/10/12/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/12/on",
+        "output": "/chsend/10/12/mix_on"
+    },
+    {
+        "input": "/ch/10/send/13/lvl",
+        "output": "/chsend/10/13/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/13/on",
+        "output": "/chsend/10/13/mix_on"
+    },
+    {
+        "input": "/ch/10/send/14/lvl",
+        "output": "/chsend/10/14/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/14/on",
+        "output": "/chsend/10/14/mix_on"
+    },
+    {
+        "input": "/ch/10/send/15/lvl",
+        "output": "/chsend/10/15/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/15/on",
+        "output": "/chsend/10/15/mix_on"
+    },
+    {
+        "input": "/ch/10/send/16/lvl",
+        "output": "/chsend/10/16/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/16/on",
+        "output": "/chsend/10/16/mix_on"
+    },
+    {
+        "input": "/ch/10/send/2/lvl",
+        "output": "/chsend/10/2/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/2/on",
+        "output": "/chsend/10/2/mix_on"
+    },
+    {
+        "input": "/ch/10/send/3/lvl",
+        "output": "/chsend/10/3/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/3/on",
+        "output": "/chsend/10/3/mix_on"
+    },
+    {
+        "input": "/ch/10/send/4/lvl",
+        "output": "/chsend/10/4/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/4/on",
+        "output": "/chsend/10/4/mix_on"
+    },
+    {
+        "input": "/ch/10/send/5/lvl",
+        "output": "/chsend/10/5/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/5/on",
+        "output": "/chsend/10/5/mix_on"
+    },
+    {
+        "input": "/ch/10/send/6/lvl",
+        "output": "/chsend/10/6/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/6/on",
+        "output": "/chsend/10/6/mix_on"
+    },
+    {
+        "input": "/ch/10/send/7/lvl",
+        "output": "/chsend/10/7/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/7/on",
+        "output": "/chsend/10/7/mix_on"
+    },
+    {
+        "input": "/ch/10/send/8/lvl",
+        "output": "/chsend/10/8/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/8/on",
+        "output": "/chsend/10/8/mix_on"
+    },
+    {
+        "input": "/ch/10/send/9/lvl",
+        "output": "/chsend/10/9/mix_fader"
+    },
+    {
+        "input": "/ch/10/send/9/on",
+        "output": "/chsend/10/9/mix_on"
+    },
+    {
+        "input": "/ch/11/col",
+        "output": "/ch/11/config_color"
+    },
+    {
+        "input": "/ch/11/fdr",
+        "output": "/ch/11/mix_fader"
+    },
+    {
+        "input": "/ch/11/in/conn/altgrp",
+        "output": "/ch/11/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/11/in/conn/altin",
+        "output": "/ch/11/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/11/in/conn/grp",
+        "output": "/ch/11/input_conn_grp"
+    },
+    {
+        "input": "/ch/11/in/conn/in",
+        "output": "/ch/11/input_conn_in"
+    },
+    {
+        "input": "/ch/11/in/set/$g",
+        "output": "/ch/11/preamp_gain"
+    },
+    {
+        "input": "/ch/11/in/set/$mode",
+        "output": "/ch/11/input_mode"
+    },
+    {
+        "input": "/ch/11/in/set/$vph",
+        "output": "/ch/11/preamp_phantom"
+    },
+    {
+        "input": "/ch/11/in/set/altsrc",
+        "output": "/ch/11/input_altsrc"
+    },
+    {
+        "input": "/ch/11/in/set/bal",
+        "output": "/ch/11/input_balance"
+    },
+    {
+        "input": "/ch/11/in/set/dly",
+        "output": "/ch/11/input_delay"
+    },
+    {
+        "input": "/ch/11/in/set/dlymode",
+        "output": "/ch/11/input_delay_mode"
+    },
+    {
+        "input": "/ch/11/in/set/dlyon",
+        "output": "/ch/11/input_delay_on"
+    },
+    {
+        "input": "/ch/11/in/set/inv",
+        "output": "/ch/11/input_invert"
+    },
+    {
+        "input": "/ch/11/in/set/srcauto",
+        "output": "/ch/11/input_srcauto"
+    },
+    {
+        "input": "/ch/11/in/set/trim",
+        "output": "/ch/11/input_trim"
+    },
+    {
+        "input": "/ch/11/mute",
+        "output": "/ch/11/mix_on"
+    },
+    {
+        "input": "/ch/11/name",
+        "output": "/ch/11/config_name"
+    },
+    {
+        "input": "/ch/11/send/1/lvl",
+        "output": "/chsend/11/1/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/1/on",
+        "output": "/chsend/11/1/mix_on"
+    },
+    {
+        "input": "/ch/11/send/10/lvl",
+        "output": "/chsend/11/10/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/10/on",
+        "output": "/chsend/11/10/mix_on"
+    },
+    {
+        "input": "/ch/11/send/11/lvl",
+        "output": "/chsend/11/11/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/11/on",
+        "output": "/chsend/11/11/mix_on"
+    },
+    {
+        "input": "/ch/11/send/12/lvl",
+        "output": "/chsend/11/12/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/12/on",
+        "output": "/chsend/11/12/mix_on"
+    },
+    {
+        "input": "/ch/11/send/13/lvl",
+        "output": "/chsend/11/13/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/13/on",
+        "output": "/chsend/11/13/mix_on"
+    },
+    {
+        "input": "/ch/11/send/14/lvl",
+        "output": "/chsend/11/14/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/14/on",
+        "output": "/chsend/11/14/mix_on"
+    },
+    {
+        "input": "/ch/11/send/15/lvl",
+        "output": "/chsend/11/15/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/15/on",
+        "output": "/chsend/11/15/mix_on"
+    },
+    {
+        "input": "/ch/11/send/16/lvl",
+        "output": "/chsend/11/16/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/16/on",
+        "output": "/chsend/11/16/mix_on"
+    },
+    {
+        "input": "/ch/11/send/2/lvl",
+        "output": "/chsend/11/2/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/2/on",
+        "output": "/chsend/11/2/mix_on"
+    },
+    {
+        "input": "/ch/11/send/3/lvl",
+        "output": "/chsend/11/3/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/3/on",
+        "output": "/chsend/11/3/mix_on"
+    },
+    {
+        "input": "/ch/11/send/4/lvl",
+        "output": "/chsend/11/4/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/4/on",
+        "output": "/chsend/11/4/mix_on"
+    },
+    {
+        "input": "/ch/11/send/5/lvl",
+        "output": "/chsend/11/5/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/5/on",
+        "output": "/chsend/11/5/mix_on"
+    },
+    {
+        "input": "/ch/11/send/6/lvl",
+        "output": "/chsend/11/6/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/6/on",
+        "output": "/chsend/11/6/mix_on"
+    },
+    {
+        "input": "/ch/11/send/7/lvl",
+        "output": "/chsend/11/7/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/7/on",
+        "output": "/chsend/11/7/mix_on"
+    },
+    {
+        "input": "/ch/11/send/8/lvl",
+        "output": "/chsend/11/8/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/8/on",
+        "output": "/chsend/11/8/mix_on"
+    },
+    {
+        "input": "/ch/11/send/9/lvl",
+        "output": "/chsend/11/9/mix_fader"
+    },
+    {
+        "input": "/ch/11/send/9/on",
+        "output": "/chsend/11/9/mix_on"
+    },
+    {
+        "input": "/ch/12/col",
+        "output": "/ch/12/config_color"
+    },
+    {
+        "input": "/ch/12/fdr",
+        "output": "/ch/12/mix_fader"
+    },
+    {
+        "input": "/ch/12/in/conn/altgrp",
+        "output": "/ch/12/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/12/in/conn/altin",
+        "output": "/ch/12/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/12/in/conn/grp",
+        "output": "/ch/12/input_conn_grp"
+    },
+    {
+        "input": "/ch/12/in/conn/in",
+        "output": "/ch/12/input_conn_in"
+    },
+    {
+        "input": "/ch/12/in/set/$g",
+        "output": "/ch/12/preamp_gain"
+    },
+    {
+        "input": "/ch/12/in/set/$mode",
+        "output": "/ch/12/input_mode"
+    },
+    {
+        "input": "/ch/12/in/set/$vph",
+        "output": "/ch/12/preamp_phantom"
+    },
+    {
+        "input": "/ch/12/in/set/altsrc",
+        "output": "/ch/12/input_altsrc"
+    },
+    {
+        "input": "/ch/12/in/set/bal",
+        "output": "/ch/12/input_balance"
+    },
+    {
+        "input": "/ch/12/in/set/dly",
+        "output": "/ch/12/input_delay"
+    },
+    {
+        "input": "/ch/12/in/set/dlymode",
+        "output": "/ch/12/input_delay_mode"
+    },
+    {
+        "input": "/ch/12/in/set/dlyon",
+        "output": "/ch/12/input_delay_on"
+    },
+    {
+        "input": "/ch/12/in/set/inv",
+        "output": "/ch/12/input_invert"
+    },
+    {
+        "input": "/ch/12/in/set/srcauto",
+        "output": "/ch/12/input_srcauto"
+    },
+    {
+        "input": "/ch/12/in/set/trim",
+        "output": "/ch/12/input_trim"
+    },
+    {
+        "input": "/ch/12/mute",
+        "output": "/ch/12/mix_on"
+    },
+    {
+        "input": "/ch/12/name",
+        "output": "/ch/12/config_name"
+    },
+    {
+        "input": "/ch/12/send/1/lvl",
+        "output": "/chsend/12/1/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/1/on",
+        "output": "/chsend/12/1/mix_on"
+    },
+    {
+        "input": "/ch/12/send/10/lvl",
+        "output": "/chsend/12/10/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/10/on",
+        "output": "/chsend/12/10/mix_on"
+    },
+    {
+        "input": "/ch/12/send/11/lvl",
+        "output": "/chsend/12/11/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/11/on",
+        "output": "/chsend/12/11/mix_on"
+    },
+    {
+        "input": "/ch/12/send/12/lvl",
+        "output": "/chsend/12/12/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/12/on",
+        "output": "/chsend/12/12/mix_on"
+    },
+    {
+        "input": "/ch/12/send/13/lvl",
+        "output": "/chsend/12/13/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/13/on",
+        "output": "/chsend/12/13/mix_on"
+    },
+    {
+        "input": "/ch/12/send/14/lvl",
+        "output": "/chsend/12/14/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/14/on",
+        "output": "/chsend/12/14/mix_on"
+    },
+    {
+        "input": "/ch/12/send/15/lvl",
+        "output": "/chsend/12/15/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/15/on",
+        "output": "/chsend/12/15/mix_on"
+    },
+    {
+        "input": "/ch/12/send/16/lvl",
+        "output": "/chsend/12/16/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/16/on",
+        "output": "/chsend/12/16/mix_on"
+    },
+    {
+        "input": "/ch/12/send/2/lvl",
+        "output": "/chsend/12/2/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/2/on",
+        "output": "/chsend/12/2/mix_on"
+    },
+    {
+        "input": "/ch/12/send/3/lvl",
+        "output": "/chsend/12/3/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/3/on",
+        "output": "/chsend/12/3/mix_on"
+    },
+    {
+        "input": "/ch/12/send/4/lvl",
+        "output": "/chsend/12/4/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/4/on",
+        "output": "/chsend/12/4/mix_on"
+    },
+    {
+        "input": "/ch/12/send/5/lvl",
+        "output": "/chsend/12/5/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/5/on",
+        "output": "/chsend/12/5/mix_on"
+    },
+    {
+        "input": "/ch/12/send/6/lvl",
+        "output": "/chsend/12/6/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/6/on",
+        "output": "/chsend/12/6/mix_on"
+    },
+    {
+        "input": "/ch/12/send/7/lvl",
+        "output": "/chsend/12/7/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/7/on",
+        "output": "/chsend/12/7/mix_on"
+    },
+    {
+        "input": "/ch/12/send/8/lvl",
+        "output": "/chsend/12/8/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/8/on",
+        "output": "/chsend/12/8/mix_on"
+    },
+    {
+        "input": "/ch/12/send/9/lvl",
+        "output": "/chsend/12/9/mix_fader"
+    },
+    {
+        "input": "/ch/12/send/9/on",
+        "output": "/chsend/12/9/mix_on"
+    },
+    {
+        "input": "/ch/13/col",
+        "output": "/ch/13/config_color"
+    },
+    {
+        "input": "/ch/13/fdr",
+        "output": "/ch/13/mix_fader"
+    },
+    {
+        "input": "/ch/13/in/conn/altgrp",
+        "output": "/ch/13/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/13/in/conn/altin",
+        "output": "/ch/13/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/13/in/conn/grp",
+        "output": "/ch/13/input_conn_grp"
+    },
+    {
+        "input": "/ch/13/in/conn/in",
+        "output": "/ch/13/input_conn_in"
+    },
+    {
+        "input": "/ch/13/in/set/$g",
+        "output": "/ch/13/preamp_gain"
+    },
+    {
+        "input": "/ch/13/in/set/$mode",
+        "output": "/ch/13/input_mode"
+    },
+    {
+        "input": "/ch/13/in/set/$vph",
+        "output": "/ch/13/preamp_phantom"
+    },
+    {
+        "input": "/ch/13/in/set/altsrc",
+        "output": "/ch/13/input_altsrc"
+    },
+    {
+        "input": "/ch/13/in/set/bal",
+        "output": "/ch/13/input_balance"
+    },
+    {
+        "input": "/ch/13/in/set/dly",
+        "output": "/ch/13/input_delay"
+    },
+    {
+        "input": "/ch/13/in/set/dlymode",
+        "output": "/ch/13/input_delay_mode"
+    },
+    {
+        "input": "/ch/13/in/set/dlyon",
+        "output": "/ch/13/input_delay_on"
+    },
+    {
+        "input": "/ch/13/in/set/inv",
+        "output": "/ch/13/input_invert"
+    },
+    {
+        "input": "/ch/13/in/set/srcauto",
+        "output": "/ch/13/input_srcauto"
+    },
+    {
+        "input": "/ch/13/in/set/trim",
+        "output": "/ch/13/input_trim"
+    },
+    {
+        "input": "/ch/13/mute",
+        "output": "/ch/13/mix_on"
+    },
+    {
+        "input": "/ch/13/name",
+        "output": "/ch/13/config_name"
+    },
+    {
+        "input": "/ch/13/send/1/lvl",
+        "output": "/chsend/13/1/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/1/on",
+        "output": "/chsend/13/1/mix_on"
+    },
+    {
+        "input": "/ch/13/send/10/lvl",
+        "output": "/chsend/13/10/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/10/on",
+        "output": "/chsend/13/10/mix_on"
+    },
+    {
+        "input": "/ch/13/send/11/lvl",
+        "output": "/chsend/13/11/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/11/on",
+        "output": "/chsend/13/11/mix_on"
+    },
+    {
+        "input": "/ch/13/send/12/lvl",
+        "output": "/chsend/13/12/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/12/on",
+        "output": "/chsend/13/12/mix_on"
+    },
+    {
+        "input": "/ch/13/send/13/lvl",
+        "output": "/chsend/13/13/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/13/on",
+        "output": "/chsend/13/13/mix_on"
+    },
+    {
+        "input": "/ch/13/send/14/lvl",
+        "output": "/chsend/13/14/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/14/on",
+        "output": "/chsend/13/14/mix_on"
+    },
+    {
+        "input": "/ch/13/send/15/lvl",
+        "output": "/chsend/13/15/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/15/on",
+        "output": "/chsend/13/15/mix_on"
+    },
+    {
+        "input": "/ch/13/send/16/lvl",
+        "output": "/chsend/13/16/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/16/on",
+        "output": "/chsend/13/16/mix_on"
+    },
+    {
+        "input": "/ch/13/send/2/lvl",
+        "output": "/chsend/13/2/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/2/on",
+        "output": "/chsend/13/2/mix_on"
+    },
+    {
+        "input": "/ch/13/send/3/lvl",
+        "output": "/chsend/13/3/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/3/on",
+        "output": "/chsend/13/3/mix_on"
+    },
+    {
+        "input": "/ch/13/send/4/lvl",
+        "output": "/chsend/13/4/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/4/on",
+        "output": "/chsend/13/4/mix_on"
+    },
+    {
+        "input": "/ch/13/send/5/lvl",
+        "output": "/chsend/13/5/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/5/on",
+        "output": "/chsend/13/5/mix_on"
+    },
+    {
+        "input": "/ch/13/send/6/lvl",
+        "output": "/chsend/13/6/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/6/on",
+        "output": "/chsend/13/6/mix_on"
+    },
+    {
+        "input": "/ch/13/send/7/lvl",
+        "output": "/chsend/13/7/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/7/on",
+        "output": "/chsend/13/7/mix_on"
+    },
+    {
+        "input": "/ch/13/send/8/lvl",
+        "output": "/chsend/13/8/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/8/on",
+        "output": "/chsend/13/8/mix_on"
+    },
+    {
+        "input": "/ch/13/send/9/lvl",
+        "output": "/chsend/13/9/mix_fader"
+    },
+    {
+        "input": "/ch/13/send/9/on",
+        "output": "/chsend/13/9/mix_on"
+    },
+    {
+        "input": "/ch/14/col",
+        "output": "/ch/14/config_color"
+    },
+    {
+        "input": "/ch/14/fdr",
+        "output": "/ch/14/mix_fader"
+    },
+    {
+        "input": "/ch/14/in/conn/altgrp",
+        "output": "/ch/14/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/14/in/conn/altin",
+        "output": "/ch/14/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/14/in/conn/grp",
+        "output": "/ch/14/input_conn_grp"
+    },
+    {
+        "input": "/ch/14/in/conn/in",
+        "output": "/ch/14/input_conn_in"
+    },
+    {
+        "input": "/ch/14/in/set/$g",
+        "output": "/ch/14/preamp_gain"
+    },
+    {
+        "input": "/ch/14/in/set/$mode",
+        "output": "/ch/14/input_mode"
+    },
+    {
+        "input": "/ch/14/in/set/$vph",
+        "output": "/ch/14/preamp_phantom"
+    },
+    {
+        "input": "/ch/14/in/set/altsrc",
+        "output": "/ch/14/input_altsrc"
+    },
+    {
+        "input": "/ch/14/in/set/bal",
+        "output": "/ch/14/input_balance"
+    },
+    {
+        "input": "/ch/14/in/set/dly",
+        "output": "/ch/14/input_delay"
+    },
+    {
+        "input": "/ch/14/in/set/dlymode",
+        "output": "/ch/14/input_delay_mode"
+    },
+    {
+        "input": "/ch/14/in/set/dlyon",
+        "output": "/ch/14/input_delay_on"
+    },
+    {
+        "input": "/ch/14/in/set/inv",
+        "output": "/ch/14/input_invert"
+    },
+    {
+        "input": "/ch/14/in/set/srcauto",
+        "output": "/ch/14/input_srcauto"
+    },
+    {
+        "input": "/ch/14/in/set/trim",
+        "output": "/ch/14/input_trim"
+    },
+    {
+        "input": "/ch/14/mute",
+        "output": "/ch/14/mix_on"
+    },
+    {
+        "input": "/ch/14/name",
+        "output": "/ch/14/config_name"
+    },
+    {
+        "input": "/ch/14/send/1/lvl",
+        "output": "/chsend/14/1/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/1/on",
+        "output": "/chsend/14/1/mix_on"
+    },
+    {
+        "input": "/ch/14/send/10/lvl",
+        "output": "/chsend/14/10/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/10/on",
+        "output": "/chsend/14/10/mix_on"
+    },
+    {
+        "input": "/ch/14/send/11/lvl",
+        "output": "/chsend/14/11/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/11/on",
+        "output": "/chsend/14/11/mix_on"
+    },
+    {
+        "input": "/ch/14/send/12/lvl",
+        "output": "/chsend/14/12/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/12/on",
+        "output": "/chsend/14/12/mix_on"
+    },
+    {
+        "input": "/ch/14/send/13/lvl",
+        "output": "/chsend/14/13/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/13/on",
+        "output": "/chsend/14/13/mix_on"
+    },
+    {
+        "input": "/ch/14/send/14/lvl",
+        "output": "/chsend/14/14/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/14/on",
+        "output": "/chsend/14/14/mix_on"
+    },
+    {
+        "input": "/ch/14/send/15/lvl",
+        "output": "/chsend/14/15/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/15/on",
+        "output": "/chsend/14/15/mix_on"
+    },
+    {
+        "input": "/ch/14/send/16/lvl",
+        "output": "/chsend/14/16/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/16/on",
+        "output": "/chsend/14/16/mix_on"
+    },
+    {
+        "input": "/ch/14/send/2/lvl",
+        "output": "/chsend/14/2/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/2/on",
+        "output": "/chsend/14/2/mix_on"
+    },
+    {
+        "input": "/ch/14/send/3/lvl",
+        "output": "/chsend/14/3/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/3/on",
+        "output": "/chsend/14/3/mix_on"
+    },
+    {
+        "input": "/ch/14/send/4/lvl",
+        "output": "/chsend/14/4/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/4/on",
+        "output": "/chsend/14/4/mix_on"
+    },
+    {
+        "input": "/ch/14/send/5/lvl",
+        "output": "/chsend/14/5/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/5/on",
+        "output": "/chsend/14/5/mix_on"
+    },
+    {
+        "input": "/ch/14/send/6/lvl",
+        "output": "/chsend/14/6/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/6/on",
+        "output": "/chsend/14/6/mix_on"
+    },
+    {
+        "input": "/ch/14/send/7/lvl",
+        "output": "/chsend/14/7/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/7/on",
+        "output": "/chsend/14/7/mix_on"
+    },
+    {
+        "input": "/ch/14/send/8/lvl",
+        "output": "/chsend/14/8/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/8/on",
+        "output": "/chsend/14/8/mix_on"
+    },
+    {
+        "input": "/ch/14/send/9/lvl",
+        "output": "/chsend/14/9/mix_fader"
+    },
+    {
+        "input": "/ch/14/send/9/on",
+        "output": "/chsend/14/9/mix_on"
+    },
+    {
+        "input": "/ch/15/col",
+        "output": "/ch/15/config_color"
+    },
+    {
+        "input": "/ch/15/fdr",
+        "output": "/ch/15/mix_fader"
+    },
+    {
+        "input": "/ch/15/in/conn/altgrp",
+        "output": "/ch/15/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/15/in/conn/altin",
+        "output": "/ch/15/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/15/in/conn/grp",
+        "output": "/ch/15/input_conn_grp"
+    },
+    {
+        "input": "/ch/15/in/conn/in",
+        "output": "/ch/15/input_conn_in"
+    },
+    {
+        "input": "/ch/15/in/set/$g",
+        "output": "/ch/15/preamp_gain"
+    },
+    {
+        "input": "/ch/15/in/set/$mode",
+        "output": "/ch/15/input_mode"
+    },
+    {
+        "input": "/ch/15/in/set/$vph",
+        "output": "/ch/15/preamp_phantom"
+    },
+    {
+        "input": "/ch/15/in/set/altsrc",
+        "output": "/ch/15/input_altsrc"
+    },
+    {
+        "input": "/ch/15/in/set/bal",
+        "output": "/ch/15/input_balance"
+    },
+    {
+        "input": "/ch/15/in/set/dly",
+        "output": "/ch/15/input_delay"
+    },
+    {
+        "input": "/ch/15/in/set/dlymode",
+        "output": "/ch/15/input_delay_mode"
+    },
+    {
+        "input": "/ch/15/in/set/dlyon",
+        "output": "/ch/15/input_delay_on"
+    },
+    {
+        "input": "/ch/15/in/set/inv",
+        "output": "/ch/15/input_invert"
+    },
+    {
+        "input": "/ch/15/in/set/srcauto",
+        "output": "/ch/15/input_srcauto"
+    },
+    {
+        "input": "/ch/15/in/set/trim",
+        "output": "/ch/15/input_trim"
+    },
+    {
+        "input": "/ch/15/mute",
+        "output": "/ch/15/mix_on"
+    },
+    {
+        "input": "/ch/15/name",
+        "output": "/ch/15/config_name"
+    },
+    {
+        "input": "/ch/15/send/1/lvl",
+        "output": "/chsend/15/1/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/1/on",
+        "output": "/chsend/15/1/mix_on"
+    },
+    {
+        "input": "/ch/15/send/10/lvl",
+        "output": "/chsend/15/10/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/10/on",
+        "output": "/chsend/15/10/mix_on"
+    },
+    {
+        "input": "/ch/15/send/11/lvl",
+        "output": "/chsend/15/11/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/11/on",
+        "output": "/chsend/15/11/mix_on"
+    },
+    {
+        "input": "/ch/15/send/12/lvl",
+        "output": "/chsend/15/12/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/12/on",
+        "output": "/chsend/15/12/mix_on"
+    },
+    {
+        "input": "/ch/15/send/13/lvl",
+        "output": "/chsend/15/13/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/13/on",
+        "output": "/chsend/15/13/mix_on"
+    },
+    {
+        "input": "/ch/15/send/14/lvl",
+        "output": "/chsend/15/14/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/14/on",
+        "output": "/chsend/15/14/mix_on"
+    },
+    {
+        "input": "/ch/15/send/15/lvl",
+        "output": "/chsend/15/15/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/15/on",
+        "output": "/chsend/15/15/mix_on"
+    },
+    {
+        "input": "/ch/15/send/16/lvl",
+        "output": "/chsend/15/16/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/16/on",
+        "output": "/chsend/15/16/mix_on"
+    },
+    {
+        "input": "/ch/15/send/2/lvl",
+        "output": "/chsend/15/2/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/2/on",
+        "output": "/chsend/15/2/mix_on"
+    },
+    {
+        "input": "/ch/15/send/3/lvl",
+        "output": "/chsend/15/3/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/3/on",
+        "output": "/chsend/15/3/mix_on"
+    },
+    {
+        "input": "/ch/15/send/4/lvl",
+        "output": "/chsend/15/4/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/4/on",
+        "output": "/chsend/15/4/mix_on"
+    },
+    {
+        "input": "/ch/15/send/5/lvl",
+        "output": "/chsend/15/5/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/5/on",
+        "output": "/chsend/15/5/mix_on"
+    },
+    {
+        "input": "/ch/15/send/6/lvl",
+        "output": "/chsend/15/6/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/6/on",
+        "output": "/chsend/15/6/mix_on"
+    },
+    {
+        "input": "/ch/15/send/7/lvl",
+        "output": "/chsend/15/7/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/7/on",
+        "output": "/chsend/15/7/mix_on"
+    },
+    {
+        "input": "/ch/15/send/8/lvl",
+        "output": "/chsend/15/8/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/8/on",
+        "output": "/chsend/15/8/mix_on"
+    },
+    {
+        "input": "/ch/15/send/9/lvl",
+        "output": "/chsend/15/9/mix_fader"
+    },
+    {
+        "input": "/ch/15/send/9/on",
+        "output": "/chsend/15/9/mix_on"
+    },
+    {
+        "input": "/ch/16/col",
+        "output": "/ch/16/config_color"
+    },
+    {
+        "input": "/ch/16/fdr",
+        "output": "/ch/16/mix_fader"
+    },
+    {
+        "input": "/ch/16/in/conn/altgrp",
+        "output": "/ch/16/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/16/in/conn/altin",
+        "output": "/ch/16/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/16/in/conn/grp",
+        "output": "/ch/16/input_conn_grp"
+    },
+    {
+        "input": "/ch/16/in/conn/in",
+        "output": "/ch/16/input_conn_in"
+    },
+    {
+        "input": "/ch/16/in/set/$g",
+        "output": "/ch/16/preamp_gain"
+    },
+    {
+        "input": "/ch/16/in/set/$mode",
+        "output": "/ch/16/input_mode"
+    },
+    {
+        "input": "/ch/16/in/set/$vph",
+        "output": "/ch/16/preamp_phantom"
+    },
+    {
+        "input": "/ch/16/in/set/altsrc",
+        "output": "/ch/16/input_altsrc"
+    },
+    {
+        "input": "/ch/16/in/set/bal",
+        "output": "/ch/16/input_balance"
+    },
+    {
+        "input": "/ch/16/in/set/dly",
+        "output": "/ch/16/input_delay"
+    },
+    {
+        "input": "/ch/16/in/set/dlymode",
+        "output": "/ch/16/input_delay_mode"
+    },
+    {
+        "input": "/ch/16/in/set/dlyon",
+        "output": "/ch/16/input_delay_on"
+    },
+    {
+        "input": "/ch/16/in/set/inv",
+        "output": "/ch/16/input_invert"
+    },
+    {
+        "input": "/ch/16/in/set/srcauto",
+        "output": "/ch/16/input_srcauto"
+    },
+    {
+        "input": "/ch/16/in/set/trim",
+        "output": "/ch/16/input_trim"
+    },
+    {
+        "input": "/ch/16/mute",
+        "output": "/ch/16/mix_on"
+    },
+    {
+        "input": "/ch/16/name",
+        "output": "/ch/16/config_name"
+    },
+    {
+        "input": "/ch/16/send/1/lvl",
+        "output": "/chsend/16/1/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/1/on",
+        "output": "/chsend/16/1/mix_on"
+    },
+    {
+        "input": "/ch/16/send/10/lvl",
+        "output": "/chsend/16/10/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/10/on",
+        "output": "/chsend/16/10/mix_on"
+    },
+    {
+        "input": "/ch/16/send/11/lvl",
+        "output": "/chsend/16/11/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/11/on",
+        "output": "/chsend/16/11/mix_on"
+    },
+    {
+        "input": "/ch/16/send/12/lvl",
+        "output": "/chsend/16/12/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/12/on",
+        "output": "/chsend/16/12/mix_on"
+    },
+    {
+        "input": "/ch/16/send/13/lvl",
+        "output": "/chsend/16/13/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/13/on",
+        "output": "/chsend/16/13/mix_on"
+    },
+    {
+        "input": "/ch/16/send/14/lvl",
+        "output": "/chsend/16/14/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/14/on",
+        "output": "/chsend/16/14/mix_on"
+    },
+    {
+        "input": "/ch/16/send/15/lvl",
+        "output": "/chsend/16/15/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/15/on",
+        "output": "/chsend/16/15/mix_on"
+    },
+    {
+        "input": "/ch/16/send/16/lvl",
+        "output": "/chsend/16/16/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/16/on",
+        "output": "/chsend/16/16/mix_on"
+    },
+    {
+        "input": "/ch/16/send/2/lvl",
+        "output": "/chsend/16/2/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/2/on",
+        "output": "/chsend/16/2/mix_on"
+    },
+    {
+        "input": "/ch/16/send/3/lvl",
+        "output": "/chsend/16/3/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/3/on",
+        "output": "/chsend/16/3/mix_on"
+    },
+    {
+        "input": "/ch/16/send/4/lvl",
+        "output": "/chsend/16/4/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/4/on",
+        "output": "/chsend/16/4/mix_on"
+    },
+    {
+        "input": "/ch/16/send/5/lvl",
+        "output": "/chsend/16/5/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/5/on",
+        "output": "/chsend/16/5/mix_on"
+    },
+    {
+        "input": "/ch/16/send/6/lvl",
+        "output": "/chsend/16/6/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/6/on",
+        "output": "/chsend/16/6/mix_on"
+    },
+    {
+        "input": "/ch/16/send/7/lvl",
+        "output": "/chsend/16/7/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/7/on",
+        "output": "/chsend/16/7/mix_on"
+    },
+    {
+        "input": "/ch/16/send/8/lvl",
+        "output": "/chsend/16/8/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/8/on",
+        "output": "/chsend/16/8/mix_on"
+    },
+    {
+        "input": "/ch/16/send/9/lvl",
+        "output": "/chsend/16/9/mix_fader"
+    },
+    {
+        "input": "/ch/16/send/9/on",
+        "output": "/chsend/16/9/mix_on"
+    },
+    {
+        "input": "/ch/17/col",
+        "output": "/ch/17/config_color"
+    },
+    {
+        "input": "/ch/17/fdr",
+        "output": "/ch/17/mix_fader"
+    },
+    {
+        "input": "/ch/17/in/conn/altgrp",
+        "output": "/ch/17/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/17/in/conn/altin",
+        "output": "/ch/17/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/17/in/conn/grp",
+        "output": "/ch/17/input_conn_grp"
+    },
+    {
+        "input": "/ch/17/in/conn/in",
+        "output": "/ch/17/input_conn_in"
+    },
+    {
+        "input": "/ch/17/in/set/$g",
+        "output": "/ch/17/preamp_gain"
+    },
+    {
+        "input": "/ch/17/in/set/$mode",
+        "output": "/ch/17/input_mode"
+    },
+    {
+        "input": "/ch/17/in/set/$vph",
+        "output": "/ch/17/preamp_phantom"
+    },
+    {
+        "input": "/ch/17/in/set/altsrc",
+        "output": "/ch/17/input_altsrc"
+    },
+    {
+        "input": "/ch/17/in/set/bal",
+        "output": "/ch/17/input_balance"
+    },
+    {
+        "input": "/ch/17/in/set/dly",
+        "output": "/ch/17/input_delay"
+    },
+    {
+        "input": "/ch/17/in/set/dlymode",
+        "output": "/ch/17/input_delay_mode"
+    },
+    {
+        "input": "/ch/17/in/set/dlyon",
+        "output": "/ch/17/input_delay_on"
+    },
+    {
+        "input": "/ch/17/in/set/inv",
+        "output": "/ch/17/input_invert"
+    },
+    {
+        "input": "/ch/17/in/set/srcauto",
+        "output": "/ch/17/input_srcauto"
+    },
+    {
+        "input": "/ch/17/in/set/trim",
+        "output": "/ch/17/input_trim"
+    },
+    {
+        "input": "/ch/17/mute",
+        "output": "/ch/17/mix_on"
+    },
+    {
+        "input": "/ch/17/name",
+        "output": "/ch/17/config_name"
+    },
+    {
+        "input": "/ch/17/send/1/lvl",
+        "output": "/chsend/17/1/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/1/on",
+        "output": "/chsend/17/1/mix_on"
+    },
+    {
+        "input": "/ch/17/send/10/lvl",
+        "output": "/chsend/17/10/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/10/on",
+        "output": "/chsend/17/10/mix_on"
+    },
+    {
+        "input": "/ch/17/send/11/lvl",
+        "output": "/chsend/17/11/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/11/on",
+        "output": "/chsend/17/11/mix_on"
+    },
+    {
+        "input": "/ch/17/send/12/lvl",
+        "output": "/chsend/17/12/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/12/on",
+        "output": "/chsend/17/12/mix_on"
+    },
+    {
+        "input": "/ch/17/send/13/lvl",
+        "output": "/chsend/17/13/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/13/on",
+        "output": "/chsend/17/13/mix_on"
+    },
+    {
+        "input": "/ch/17/send/14/lvl",
+        "output": "/chsend/17/14/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/14/on",
+        "output": "/chsend/17/14/mix_on"
+    },
+    {
+        "input": "/ch/17/send/15/lvl",
+        "output": "/chsend/17/15/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/15/on",
+        "output": "/chsend/17/15/mix_on"
+    },
+    {
+        "input": "/ch/17/send/16/lvl",
+        "output": "/chsend/17/16/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/16/on",
+        "output": "/chsend/17/16/mix_on"
+    },
+    {
+        "input": "/ch/17/send/2/lvl",
+        "output": "/chsend/17/2/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/2/on",
+        "output": "/chsend/17/2/mix_on"
+    },
+    {
+        "input": "/ch/17/send/3/lvl",
+        "output": "/chsend/17/3/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/3/on",
+        "output": "/chsend/17/3/mix_on"
+    },
+    {
+        "input": "/ch/17/send/4/lvl",
+        "output": "/chsend/17/4/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/4/on",
+        "output": "/chsend/17/4/mix_on"
+    },
+    {
+        "input": "/ch/17/send/5/lvl",
+        "output": "/chsend/17/5/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/5/on",
+        "output": "/chsend/17/5/mix_on"
+    },
+    {
+        "input": "/ch/17/send/6/lvl",
+        "output": "/chsend/17/6/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/6/on",
+        "output": "/chsend/17/6/mix_on"
+    },
+    {
+        "input": "/ch/17/send/7/lvl",
+        "output": "/chsend/17/7/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/7/on",
+        "output": "/chsend/17/7/mix_on"
+    },
+    {
+        "input": "/ch/17/send/8/lvl",
+        "output": "/chsend/17/8/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/8/on",
+        "output": "/chsend/17/8/mix_on"
+    },
+    {
+        "input": "/ch/17/send/9/lvl",
+        "output": "/chsend/17/9/mix_fader"
+    },
+    {
+        "input": "/ch/17/send/9/on",
+        "output": "/chsend/17/9/mix_on"
+    },
+    {
+        "input": "/ch/18/col",
+        "output": "/ch/18/config_color"
+    },
+    {
+        "input": "/ch/18/fdr",
+        "output": "/ch/18/mix_fader"
+    },
+    {
+        "input": "/ch/18/in/conn/altgrp",
+        "output": "/ch/18/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/18/in/conn/altin",
+        "output": "/ch/18/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/18/in/conn/grp",
+        "output": "/ch/18/input_conn_grp"
+    },
+    {
+        "input": "/ch/18/in/conn/in",
+        "output": "/ch/18/input_conn_in"
+    },
+    {
+        "input": "/ch/18/in/set/$g",
+        "output": "/ch/18/preamp_gain"
+    },
+    {
+        "input": "/ch/18/in/set/$mode",
+        "output": "/ch/18/input_mode"
+    },
+    {
+        "input": "/ch/18/in/set/$vph",
+        "output": "/ch/18/preamp_phantom"
+    },
+    {
+        "input": "/ch/18/in/set/altsrc",
+        "output": "/ch/18/input_altsrc"
+    },
+    {
+        "input": "/ch/18/in/set/bal",
+        "output": "/ch/18/input_balance"
+    },
+    {
+        "input": "/ch/18/in/set/dly",
+        "output": "/ch/18/input_delay"
+    },
+    {
+        "input": "/ch/18/in/set/dlymode",
+        "output": "/ch/18/input_delay_mode"
+    },
+    {
+        "input": "/ch/18/in/set/dlyon",
+        "output": "/ch/18/input_delay_on"
+    },
+    {
+        "input": "/ch/18/in/set/inv",
+        "output": "/ch/18/input_invert"
+    },
+    {
+        "input": "/ch/18/in/set/srcauto",
+        "output": "/ch/18/input_srcauto"
+    },
+    {
+        "input": "/ch/18/in/set/trim",
+        "output": "/ch/18/input_trim"
+    },
+    {
+        "input": "/ch/18/mute",
+        "output": "/ch/18/mix_on"
+    },
+    {
+        "input": "/ch/18/name",
+        "output": "/ch/18/config_name"
+    },
+    {
+        "input": "/ch/18/send/1/lvl",
+        "output": "/chsend/18/1/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/1/on",
+        "output": "/chsend/18/1/mix_on"
+    },
+    {
+        "input": "/ch/18/send/10/lvl",
+        "output": "/chsend/18/10/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/10/on",
+        "output": "/chsend/18/10/mix_on"
+    },
+    {
+        "input": "/ch/18/send/11/lvl",
+        "output": "/chsend/18/11/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/11/on",
+        "output": "/chsend/18/11/mix_on"
+    },
+    {
+        "input": "/ch/18/send/12/lvl",
+        "output": "/chsend/18/12/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/12/on",
+        "output": "/chsend/18/12/mix_on"
+    },
+    {
+        "input": "/ch/18/send/13/lvl",
+        "output": "/chsend/18/13/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/13/on",
+        "output": "/chsend/18/13/mix_on"
+    },
+    {
+        "input": "/ch/18/send/14/lvl",
+        "output": "/chsend/18/14/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/14/on",
+        "output": "/chsend/18/14/mix_on"
+    },
+    {
+        "input": "/ch/18/send/15/lvl",
+        "output": "/chsend/18/15/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/15/on",
+        "output": "/chsend/18/15/mix_on"
+    },
+    {
+        "input": "/ch/18/send/16/lvl",
+        "output": "/chsend/18/16/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/16/on",
+        "output": "/chsend/18/16/mix_on"
+    },
+    {
+        "input": "/ch/18/send/2/lvl",
+        "output": "/chsend/18/2/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/2/on",
+        "output": "/chsend/18/2/mix_on"
+    },
+    {
+        "input": "/ch/18/send/3/lvl",
+        "output": "/chsend/18/3/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/3/on",
+        "output": "/chsend/18/3/mix_on"
+    },
+    {
+        "input": "/ch/18/send/4/lvl",
+        "output": "/chsend/18/4/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/4/on",
+        "output": "/chsend/18/4/mix_on"
+    },
+    {
+        "input": "/ch/18/send/5/lvl",
+        "output": "/chsend/18/5/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/5/on",
+        "output": "/chsend/18/5/mix_on"
+    },
+    {
+        "input": "/ch/18/send/6/lvl",
+        "output": "/chsend/18/6/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/6/on",
+        "output": "/chsend/18/6/mix_on"
+    },
+    {
+        "input": "/ch/18/send/7/lvl",
+        "output": "/chsend/18/7/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/7/on",
+        "output": "/chsend/18/7/mix_on"
+    },
+    {
+        "input": "/ch/18/send/8/lvl",
+        "output": "/chsend/18/8/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/8/on",
+        "output": "/chsend/18/8/mix_on"
+    },
+    {
+        "input": "/ch/18/send/9/lvl",
+        "output": "/chsend/18/9/mix_fader"
+    },
+    {
+        "input": "/ch/18/send/9/on",
+        "output": "/chsend/18/9/mix_on"
+    },
+    {
+        "input": "/ch/19/col",
+        "output": "/ch/19/config_color"
+    },
+    {
+        "input": "/ch/19/fdr",
+        "output": "/ch/19/mix_fader"
+    },
+    {
+        "input": "/ch/19/in/conn/altgrp",
+        "output": "/ch/19/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/19/in/conn/altin",
+        "output": "/ch/19/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/19/in/conn/grp",
+        "output": "/ch/19/input_conn_grp"
+    },
+    {
+        "input": "/ch/19/in/conn/in",
+        "output": "/ch/19/input_conn_in"
+    },
+    {
+        "input": "/ch/19/in/set/$g",
+        "output": "/ch/19/preamp_gain"
+    },
+    {
+        "input": "/ch/19/in/set/$mode",
+        "output": "/ch/19/input_mode"
+    },
+    {
+        "input": "/ch/19/in/set/$vph",
+        "output": "/ch/19/preamp_phantom"
+    },
+    {
+        "input": "/ch/19/in/set/altsrc",
+        "output": "/ch/19/input_altsrc"
+    },
+    {
+        "input": "/ch/19/in/set/bal",
+        "output": "/ch/19/input_balance"
+    },
+    {
+        "input": "/ch/19/in/set/dly",
+        "output": "/ch/19/input_delay"
+    },
+    {
+        "input": "/ch/19/in/set/dlymode",
+        "output": "/ch/19/input_delay_mode"
+    },
+    {
+        "input": "/ch/19/in/set/dlyon",
+        "output": "/ch/19/input_delay_on"
+    },
+    {
+        "input": "/ch/19/in/set/inv",
+        "output": "/ch/19/input_invert"
+    },
+    {
+        "input": "/ch/19/in/set/srcauto",
+        "output": "/ch/19/input_srcauto"
+    },
+    {
+        "input": "/ch/19/in/set/trim",
+        "output": "/ch/19/input_trim"
+    },
+    {
+        "input": "/ch/19/mute",
+        "output": "/ch/19/mix_on"
+    },
+    {
+        "input": "/ch/19/name",
+        "output": "/ch/19/config_name"
+    },
+    {
+        "input": "/ch/19/send/1/lvl",
+        "output": "/chsend/19/1/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/1/on",
+        "output": "/chsend/19/1/mix_on"
+    },
+    {
+        "input": "/ch/19/send/10/lvl",
+        "output": "/chsend/19/10/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/10/on",
+        "output": "/chsend/19/10/mix_on"
+    },
+    {
+        "input": "/ch/19/send/11/lvl",
+        "output": "/chsend/19/11/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/11/on",
+        "output": "/chsend/19/11/mix_on"
+    },
+    {
+        "input": "/ch/19/send/12/lvl",
+        "output": "/chsend/19/12/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/12/on",
+        "output": "/chsend/19/12/mix_on"
+    },
+    {
+        "input": "/ch/19/send/13/lvl",
+        "output": "/chsend/19/13/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/13/on",
+        "output": "/chsend/19/13/mix_on"
+    },
+    {
+        "input": "/ch/19/send/14/lvl",
+        "output": "/chsend/19/14/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/14/on",
+        "output": "/chsend/19/14/mix_on"
+    },
+    {
+        "input": "/ch/19/send/15/lvl",
+        "output": "/chsend/19/15/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/15/on",
+        "output": "/chsend/19/15/mix_on"
+    },
+    {
+        "input": "/ch/19/send/16/lvl",
+        "output": "/chsend/19/16/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/16/on",
+        "output": "/chsend/19/16/mix_on"
+    },
+    {
+        "input": "/ch/19/send/2/lvl",
+        "output": "/chsend/19/2/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/2/on",
+        "output": "/chsend/19/2/mix_on"
+    },
+    {
+        "input": "/ch/19/send/3/lvl",
+        "output": "/chsend/19/3/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/3/on",
+        "output": "/chsend/19/3/mix_on"
+    },
+    {
+        "input": "/ch/19/send/4/lvl",
+        "output": "/chsend/19/4/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/4/on",
+        "output": "/chsend/19/4/mix_on"
+    },
+    {
+        "input": "/ch/19/send/5/lvl",
+        "output": "/chsend/19/5/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/5/on",
+        "output": "/chsend/19/5/mix_on"
+    },
+    {
+        "input": "/ch/19/send/6/lvl",
+        "output": "/chsend/19/6/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/6/on",
+        "output": "/chsend/19/6/mix_on"
+    },
+    {
+        "input": "/ch/19/send/7/lvl",
+        "output": "/chsend/19/7/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/7/on",
+        "output": "/chsend/19/7/mix_on"
+    },
+    {
+        "input": "/ch/19/send/8/lvl",
+        "output": "/chsend/19/8/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/8/on",
+        "output": "/chsend/19/8/mix_on"
+    },
+    {
+        "input": "/ch/19/send/9/lvl",
+        "output": "/chsend/19/9/mix_fader"
+    },
+    {
+        "input": "/ch/19/send/9/on",
+        "output": "/chsend/19/9/mix_on"
+    },
+    {
+        "input": "/ch/2/col",
+        "output": "/ch/2/config_color"
+    },
+    {
+        "input": "/ch/2/fdr",
+        "output": "/ch/2/mix_fader"
+    },
+    {
+        "input": "/ch/2/in/conn/altgrp",
+        "output": "/ch/2/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/2/in/conn/altin",
+        "output": "/ch/2/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/2/in/conn/grp",
+        "output": "/ch/2/input_conn_grp"
+    },
+    {
+        "input": "/ch/2/in/conn/in",
+        "output": "/ch/2/input_conn_in"
+    },
+    {
+        "input": "/ch/2/in/set/$g",
+        "output": "/ch/2/preamp_gain"
+    },
+    {
+        "input": "/ch/2/in/set/$mode",
+        "output": "/ch/2/input_mode"
+    },
+    {
+        "input": "/ch/2/in/set/$vph",
+        "output": "/ch/2/preamp_phantom"
+    },
+    {
+        "input": "/ch/2/in/set/altsrc",
+        "output": "/ch/2/input_altsrc"
+    },
+    {
+        "input": "/ch/2/in/set/bal",
+        "output": "/ch/2/input_balance"
+    },
+    {
+        "input": "/ch/2/in/set/dly",
+        "output": "/ch/2/input_delay"
+    },
+    {
+        "input": "/ch/2/in/set/dlymode",
+        "output": "/ch/2/input_delay_mode"
+    },
+    {
+        "input": "/ch/2/in/set/dlyon",
+        "output": "/ch/2/input_delay_on"
+    },
+    {
+        "input": "/ch/2/in/set/inv",
+        "output": "/ch/2/input_invert"
+    },
+    {
+        "input": "/ch/2/in/set/srcauto",
+        "output": "/ch/2/input_srcauto"
+    },
+    {
+        "input": "/ch/2/in/set/trim",
+        "output": "/ch/2/input_trim"
+    },
+    {
+        "input": "/ch/2/mute",
+        "output": "/ch/2/mix_on"
+    },
+    {
+        "input": "/ch/2/name",
+        "output": "/ch/2/config_name"
+    },
+    {
+        "input": "/ch/2/send/1/lvl",
+        "output": "/chsend/2/1/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/1/on",
+        "output": "/chsend/2/1/mix_on"
+    },
+    {
+        "input": "/ch/2/send/10/lvl",
+        "output": "/chsend/2/10/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/10/on",
+        "output": "/chsend/2/10/mix_on"
+    },
+    {
+        "input": "/ch/2/send/11/lvl",
+        "output": "/chsend/2/11/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/11/on",
+        "output": "/chsend/2/11/mix_on"
+    },
+    {
+        "input": "/ch/2/send/12/lvl",
+        "output": "/chsend/2/12/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/12/on",
+        "output": "/chsend/2/12/mix_on"
+    },
+    {
+        "input": "/ch/2/send/13/lvl",
+        "output": "/chsend/2/13/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/13/on",
+        "output": "/chsend/2/13/mix_on"
+    },
+    {
+        "input": "/ch/2/send/14/lvl",
+        "output": "/chsend/2/14/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/14/on",
+        "output": "/chsend/2/14/mix_on"
+    },
+    {
+        "input": "/ch/2/send/15/lvl",
+        "output": "/chsend/2/15/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/15/on",
+        "output": "/chsend/2/15/mix_on"
+    },
+    {
+        "input": "/ch/2/send/16/lvl",
+        "output": "/chsend/2/16/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/16/on",
+        "output": "/chsend/2/16/mix_on"
+    },
+    {
+        "input": "/ch/2/send/2/lvl",
+        "output": "/chsend/2/2/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/2/on",
+        "output": "/chsend/2/2/mix_on"
+    },
+    {
+        "input": "/ch/2/send/3/lvl",
+        "output": "/chsend/2/3/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/3/on",
+        "output": "/chsend/2/3/mix_on"
+    },
+    {
+        "input": "/ch/2/send/4/lvl",
+        "output": "/chsend/2/4/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/4/on",
+        "output": "/chsend/2/4/mix_on"
+    },
+    {
+        "input": "/ch/2/send/5/lvl",
+        "output": "/chsend/2/5/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/5/on",
+        "output": "/chsend/2/5/mix_on"
+    },
+    {
+        "input": "/ch/2/send/6/lvl",
+        "output": "/chsend/2/6/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/6/on",
+        "output": "/chsend/2/6/mix_on"
+    },
+    {
+        "input": "/ch/2/send/7/lvl",
+        "output": "/chsend/2/7/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/7/on",
+        "output": "/chsend/2/7/mix_on"
+    },
+    {
+        "input": "/ch/2/send/8/lvl",
+        "output": "/chsend/2/8/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/8/on",
+        "output": "/chsend/2/8/mix_on"
+    },
+    {
+        "input": "/ch/2/send/9/lvl",
+        "output": "/chsend/2/9/mix_fader"
+    },
+    {
+        "input": "/ch/2/send/9/on",
+        "output": "/chsend/2/9/mix_on"
+    },
+    {
+        "input": "/ch/20/col",
+        "output": "/ch/20/config_color"
+    },
+    {
+        "input": "/ch/20/fdr",
+        "output": "/ch/20/mix_fader"
+    },
+    {
+        "input": "/ch/20/in/conn/altgrp",
+        "output": "/ch/20/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/20/in/conn/altin",
+        "output": "/ch/20/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/20/in/conn/grp",
+        "output": "/ch/20/input_conn_grp"
+    },
+    {
+        "input": "/ch/20/in/conn/in",
+        "output": "/ch/20/input_conn_in"
+    },
+    {
+        "input": "/ch/20/in/set/$g",
+        "output": "/ch/20/preamp_gain"
+    },
+    {
+        "input": "/ch/20/in/set/$mode",
+        "output": "/ch/20/input_mode"
+    },
+    {
+        "input": "/ch/20/in/set/$vph",
+        "output": "/ch/20/preamp_phantom"
+    },
+    {
+        "input": "/ch/20/in/set/altsrc",
+        "output": "/ch/20/input_altsrc"
+    },
+    {
+        "input": "/ch/20/in/set/bal",
+        "output": "/ch/20/input_balance"
+    },
+    {
+        "input": "/ch/20/in/set/dly",
+        "output": "/ch/20/input_delay"
+    },
+    {
+        "input": "/ch/20/in/set/dlymode",
+        "output": "/ch/20/input_delay_mode"
+    },
+    {
+        "input": "/ch/20/in/set/dlyon",
+        "output": "/ch/20/input_delay_on"
+    },
+    {
+        "input": "/ch/20/in/set/inv",
+        "output": "/ch/20/input_invert"
+    },
+    {
+        "input": "/ch/20/in/set/srcauto",
+        "output": "/ch/20/input_srcauto"
+    },
+    {
+        "input": "/ch/20/in/set/trim",
+        "output": "/ch/20/input_trim"
+    },
+    {
+        "input": "/ch/20/mute",
+        "output": "/ch/20/mix_on"
+    },
+    {
+        "input": "/ch/20/name",
+        "output": "/ch/20/config_name"
+    },
+    {
+        "input": "/ch/20/send/1/lvl",
+        "output": "/chsend/20/1/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/1/on",
+        "output": "/chsend/20/1/mix_on"
+    },
+    {
+        "input": "/ch/20/send/10/lvl",
+        "output": "/chsend/20/10/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/10/on",
+        "output": "/chsend/20/10/mix_on"
+    },
+    {
+        "input": "/ch/20/send/11/lvl",
+        "output": "/chsend/20/11/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/11/on",
+        "output": "/chsend/20/11/mix_on"
+    },
+    {
+        "input": "/ch/20/send/12/lvl",
+        "output": "/chsend/20/12/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/12/on",
+        "output": "/chsend/20/12/mix_on"
+    },
+    {
+        "input": "/ch/20/send/13/lvl",
+        "output": "/chsend/20/13/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/13/on",
+        "output": "/chsend/20/13/mix_on"
+    },
+    {
+        "input": "/ch/20/send/14/lvl",
+        "output": "/chsend/20/14/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/14/on",
+        "output": "/chsend/20/14/mix_on"
+    },
+    {
+        "input": "/ch/20/send/15/lvl",
+        "output": "/chsend/20/15/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/15/on",
+        "output": "/chsend/20/15/mix_on"
+    },
+    {
+        "input": "/ch/20/send/16/lvl",
+        "output": "/chsend/20/16/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/16/on",
+        "output": "/chsend/20/16/mix_on"
+    },
+    {
+        "input": "/ch/20/send/2/lvl",
+        "output": "/chsend/20/2/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/2/on",
+        "output": "/chsend/20/2/mix_on"
+    },
+    {
+        "input": "/ch/20/send/3/lvl",
+        "output": "/chsend/20/3/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/3/on",
+        "output": "/chsend/20/3/mix_on"
+    },
+    {
+        "input": "/ch/20/send/4/lvl",
+        "output": "/chsend/20/4/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/4/on",
+        "output": "/chsend/20/4/mix_on"
+    },
+    {
+        "input": "/ch/20/send/5/lvl",
+        "output": "/chsend/20/5/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/5/on",
+        "output": "/chsend/20/5/mix_on"
+    },
+    {
+        "input": "/ch/20/send/6/lvl",
+        "output": "/chsend/20/6/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/6/on",
+        "output": "/chsend/20/6/mix_on"
+    },
+    {
+        "input": "/ch/20/send/7/lvl",
+        "output": "/chsend/20/7/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/7/on",
+        "output": "/chsend/20/7/mix_on"
+    },
+    {
+        "input": "/ch/20/send/8/lvl",
+        "output": "/chsend/20/8/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/8/on",
+        "output": "/chsend/20/8/mix_on"
+    },
+    {
+        "input": "/ch/20/send/9/lvl",
+        "output": "/chsend/20/9/mix_fader"
+    },
+    {
+        "input": "/ch/20/send/9/on",
+        "output": "/chsend/20/9/mix_on"
+    },
+    {
+        "input": "/ch/21/col",
+        "output": "/ch/21/config_color"
+    },
+    {
+        "input": "/ch/21/fdr",
+        "output": "/ch/21/mix_fader"
+    },
+    {
+        "input": "/ch/21/in/conn/altgrp",
+        "output": "/ch/21/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/21/in/conn/altin",
+        "output": "/ch/21/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/21/in/conn/grp",
+        "output": "/ch/21/input_conn_grp"
+    },
+    {
+        "input": "/ch/21/in/conn/in",
+        "output": "/ch/21/input_conn_in"
+    },
+    {
+        "input": "/ch/21/in/set/$g",
+        "output": "/ch/21/preamp_gain"
+    },
+    {
+        "input": "/ch/21/in/set/$mode",
+        "output": "/ch/21/input_mode"
+    },
+    {
+        "input": "/ch/21/in/set/$vph",
+        "output": "/ch/21/preamp_phantom"
+    },
+    {
+        "input": "/ch/21/in/set/altsrc",
+        "output": "/ch/21/input_altsrc"
+    },
+    {
+        "input": "/ch/21/in/set/bal",
+        "output": "/ch/21/input_balance"
+    },
+    {
+        "input": "/ch/21/in/set/dly",
+        "output": "/ch/21/input_delay"
+    },
+    {
+        "input": "/ch/21/in/set/dlymode",
+        "output": "/ch/21/input_delay_mode"
+    },
+    {
+        "input": "/ch/21/in/set/dlyon",
+        "output": "/ch/21/input_delay_on"
+    },
+    {
+        "input": "/ch/21/in/set/inv",
+        "output": "/ch/21/input_invert"
+    },
+    {
+        "input": "/ch/21/in/set/srcauto",
+        "output": "/ch/21/input_srcauto"
+    },
+    {
+        "input": "/ch/21/in/set/trim",
+        "output": "/ch/21/input_trim"
+    },
+    {
+        "input": "/ch/21/mute",
+        "output": "/ch/21/mix_on"
+    },
+    {
+        "input": "/ch/21/name",
+        "output": "/ch/21/config_name"
+    },
+    {
+        "input": "/ch/21/send/1/lvl",
+        "output": "/chsend/21/1/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/1/on",
+        "output": "/chsend/21/1/mix_on"
+    },
+    {
+        "input": "/ch/21/send/10/lvl",
+        "output": "/chsend/21/10/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/10/on",
+        "output": "/chsend/21/10/mix_on"
+    },
+    {
+        "input": "/ch/21/send/11/lvl",
+        "output": "/chsend/21/11/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/11/on",
+        "output": "/chsend/21/11/mix_on"
+    },
+    {
+        "input": "/ch/21/send/12/lvl",
+        "output": "/chsend/21/12/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/12/on",
+        "output": "/chsend/21/12/mix_on"
+    },
+    {
+        "input": "/ch/21/send/13/lvl",
+        "output": "/chsend/21/13/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/13/on",
+        "output": "/chsend/21/13/mix_on"
+    },
+    {
+        "input": "/ch/21/send/14/lvl",
+        "output": "/chsend/21/14/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/14/on",
+        "output": "/chsend/21/14/mix_on"
+    },
+    {
+        "input": "/ch/21/send/15/lvl",
+        "output": "/chsend/21/15/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/15/on",
+        "output": "/chsend/21/15/mix_on"
+    },
+    {
+        "input": "/ch/21/send/16/lvl",
+        "output": "/chsend/21/16/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/16/on",
+        "output": "/chsend/21/16/mix_on"
+    },
+    {
+        "input": "/ch/21/send/2/lvl",
+        "output": "/chsend/21/2/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/2/on",
+        "output": "/chsend/21/2/mix_on"
+    },
+    {
+        "input": "/ch/21/send/3/lvl",
+        "output": "/chsend/21/3/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/3/on",
+        "output": "/chsend/21/3/mix_on"
+    },
+    {
+        "input": "/ch/21/send/4/lvl",
+        "output": "/chsend/21/4/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/4/on",
+        "output": "/chsend/21/4/mix_on"
+    },
+    {
+        "input": "/ch/21/send/5/lvl",
+        "output": "/chsend/21/5/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/5/on",
+        "output": "/chsend/21/5/mix_on"
+    },
+    {
+        "input": "/ch/21/send/6/lvl",
+        "output": "/chsend/21/6/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/6/on",
+        "output": "/chsend/21/6/mix_on"
+    },
+    {
+        "input": "/ch/21/send/7/lvl",
+        "output": "/chsend/21/7/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/7/on",
+        "output": "/chsend/21/7/mix_on"
+    },
+    {
+        "input": "/ch/21/send/8/lvl",
+        "output": "/chsend/21/8/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/8/on",
+        "output": "/chsend/21/8/mix_on"
+    },
+    {
+        "input": "/ch/21/send/9/lvl",
+        "output": "/chsend/21/9/mix_fader"
+    },
+    {
+        "input": "/ch/21/send/9/on",
+        "output": "/chsend/21/9/mix_on"
+    },
+    {
+        "input": "/ch/22/col",
+        "output": "/ch/22/config_color"
+    },
+    {
+        "input": "/ch/22/fdr",
+        "output": "/ch/22/mix_fader"
+    },
+    {
+        "input": "/ch/22/in/conn/altgrp",
+        "output": "/ch/22/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/22/in/conn/altin",
+        "output": "/ch/22/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/22/in/conn/grp",
+        "output": "/ch/22/input_conn_grp"
+    },
+    {
+        "input": "/ch/22/in/conn/in",
+        "output": "/ch/22/input_conn_in"
+    },
+    {
+        "input": "/ch/22/in/set/$g",
+        "output": "/ch/22/preamp_gain"
+    },
+    {
+        "input": "/ch/22/in/set/$mode",
+        "output": "/ch/22/input_mode"
+    },
+    {
+        "input": "/ch/22/in/set/$vph",
+        "output": "/ch/22/preamp_phantom"
+    },
+    {
+        "input": "/ch/22/in/set/altsrc",
+        "output": "/ch/22/input_altsrc"
+    },
+    {
+        "input": "/ch/22/in/set/bal",
+        "output": "/ch/22/input_balance"
+    },
+    {
+        "input": "/ch/22/in/set/dly",
+        "output": "/ch/22/input_delay"
+    },
+    {
+        "input": "/ch/22/in/set/dlymode",
+        "output": "/ch/22/input_delay_mode"
+    },
+    {
+        "input": "/ch/22/in/set/dlyon",
+        "output": "/ch/22/input_delay_on"
+    },
+    {
+        "input": "/ch/22/in/set/inv",
+        "output": "/ch/22/input_invert"
+    },
+    {
+        "input": "/ch/22/in/set/srcauto",
+        "output": "/ch/22/input_srcauto"
+    },
+    {
+        "input": "/ch/22/in/set/trim",
+        "output": "/ch/22/input_trim"
+    },
+    {
+        "input": "/ch/22/mute",
+        "output": "/ch/22/mix_on"
+    },
+    {
+        "input": "/ch/22/name",
+        "output": "/ch/22/config_name"
+    },
+    {
+        "input": "/ch/22/send/1/lvl",
+        "output": "/chsend/22/1/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/1/on",
+        "output": "/chsend/22/1/mix_on"
+    },
+    {
+        "input": "/ch/22/send/10/lvl",
+        "output": "/chsend/22/10/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/10/on",
+        "output": "/chsend/22/10/mix_on"
+    },
+    {
+        "input": "/ch/22/send/11/lvl",
+        "output": "/chsend/22/11/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/11/on",
+        "output": "/chsend/22/11/mix_on"
+    },
+    {
+        "input": "/ch/22/send/12/lvl",
+        "output": "/chsend/22/12/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/12/on",
+        "output": "/chsend/22/12/mix_on"
+    },
+    {
+        "input": "/ch/22/send/13/lvl",
+        "output": "/chsend/22/13/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/13/on",
+        "output": "/chsend/22/13/mix_on"
+    },
+    {
+        "input": "/ch/22/send/14/lvl",
+        "output": "/chsend/22/14/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/14/on",
+        "output": "/chsend/22/14/mix_on"
+    },
+    {
+        "input": "/ch/22/send/15/lvl",
+        "output": "/chsend/22/15/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/15/on",
+        "output": "/chsend/22/15/mix_on"
+    },
+    {
+        "input": "/ch/22/send/16/lvl",
+        "output": "/chsend/22/16/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/16/on",
+        "output": "/chsend/22/16/mix_on"
+    },
+    {
+        "input": "/ch/22/send/2/lvl",
+        "output": "/chsend/22/2/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/2/on",
+        "output": "/chsend/22/2/mix_on"
+    },
+    {
+        "input": "/ch/22/send/3/lvl",
+        "output": "/chsend/22/3/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/3/on",
+        "output": "/chsend/22/3/mix_on"
+    },
+    {
+        "input": "/ch/22/send/4/lvl",
+        "output": "/chsend/22/4/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/4/on",
+        "output": "/chsend/22/4/mix_on"
+    },
+    {
+        "input": "/ch/22/send/5/lvl",
+        "output": "/chsend/22/5/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/5/on",
+        "output": "/chsend/22/5/mix_on"
+    },
+    {
+        "input": "/ch/22/send/6/lvl",
+        "output": "/chsend/22/6/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/6/on",
+        "output": "/chsend/22/6/mix_on"
+    },
+    {
+        "input": "/ch/22/send/7/lvl",
+        "output": "/chsend/22/7/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/7/on",
+        "output": "/chsend/22/7/mix_on"
+    },
+    {
+        "input": "/ch/22/send/8/lvl",
+        "output": "/chsend/22/8/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/8/on",
+        "output": "/chsend/22/8/mix_on"
+    },
+    {
+        "input": "/ch/22/send/9/lvl",
+        "output": "/chsend/22/9/mix_fader"
+    },
+    {
+        "input": "/ch/22/send/9/on",
+        "output": "/chsend/22/9/mix_on"
+    },
+    {
+        "input": "/ch/23/col",
+        "output": "/ch/23/config_color"
+    },
+    {
+        "input": "/ch/23/fdr",
+        "output": "/ch/23/mix_fader"
+    },
+    {
+        "input": "/ch/23/in/conn/altgrp",
+        "output": "/ch/23/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/23/in/conn/altin",
+        "output": "/ch/23/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/23/in/conn/grp",
+        "output": "/ch/23/input_conn_grp"
+    },
+    {
+        "input": "/ch/23/in/conn/in",
+        "output": "/ch/23/input_conn_in"
+    },
+    {
+        "input": "/ch/23/in/set/$g",
+        "output": "/ch/23/preamp_gain"
+    },
+    {
+        "input": "/ch/23/in/set/$mode",
+        "output": "/ch/23/input_mode"
+    },
+    {
+        "input": "/ch/23/in/set/$vph",
+        "output": "/ch/23/preamp_phantom"
+    },
+    {
+        "input": "/ch/23/in/set/altsrc",
+        "output": "/ch/23/input_altsrc"
+    },
+    {
+        "input": "/ch/23/in/set/bal",
+        "output": "/ch/23/input_balance"
+    },
+    {
+        "input": "/ch/23/in/set/dly",
+        "output": "/ch/23/input_delay"
+    },
+    {
+        "input": "/ch/23/in/set/dlymode",
+        "output": "/ch/23/input_delay_mode"
+    },
+    {
+        "input": "/ch/23/in/set/dlyon",
+        "output": "/ch/23/input_delay_on"
+    },
+    {
+        "input": "/ch/23/in/set/inv",
+        "output": "/ch/23/input_invert"
+    },
+    {
+        "input": "/ch/23/in/set/srcauto",
+        "output": "/ch/23/input_srcauto"
+    },
+    {
+        "input": "/ch/23/in/set/trim",
+        "output": "/ch/23/input_trim"
+    },
+    {
+        "input": "/ch/23/mute",
+        "output": "/ch/23/mix_on"
+    },
+    {
+        "input": "/ch/23/name",
+        "output": "/ch/23/config_name"
+    },
+    {
+        "input": "/ch/23/send/1/lvl",
+        "output": "/chsend/23/1/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/1/on",
+        "output": "/chsend/23/1/mix_on"
+    },
+    {
+        "input": "/ch/23/send/10/lvl",
+        "output": "/chsend/23/10/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/10/on",
+        "output": "/chsend/23/10/mix_on"
+    },
+    {
+        "input": "/ch/23/send/11/lvl",
+        "output": "/chsend/23/11/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/11/on",
+        "output": "/chsend/23/11/mix_on"
+    },
+    {
+        "input": "/ch/23/send/12/lvl",
+        "output": "/chsend/23/12/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/12/on",
+        "output": "/chsend/23/12/mix_on"
+    },
+    {
+        "input": "/ch/23/send/13/lvl",
+        "output": "/chsend/23/13/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/13/on",
+        "output": "/chsend/23/13/mix_on"
+    },
+    {
+        "input": "/ch/23/send/14/lvl",
+        "output": "/chsend/23/14/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/14/on",
+        "output": "/chsend/23/14/mix_on"
+    },
+    {
+        "input": "/ch/23/send/15/lvl",
+        "output": "/chsend/23/15/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/15/on",
+        "output": "/chsend/23/15/mix_on"
+    },
+    {
+        "input": "/ch/23/send/16/lvl",
+        "output": "/chsend/23/16/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/16/on",
+        "output": "/chsend/23/16/mix_on"
+    },
+    {
+        "input": "/ch/23/send/2/lvl",
+        "output": "/chsend/23/2/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/2/on",
+        "output": "/chsend/23/2/mix_on"
+    },
+    {
+        "input": "/ch/23/send/3/lvl",
+        "output": "/chsend/23/3/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/3/on",
+        "output": "/chsend/23/3/mix_on"
+    },
+    {
+        "input": "/ch/23/send/4/lvl",
+        "output": "/chsend/23/4/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/4/on",
+        "output": "/chsend/23/4/mix_on"
+    },
+    {
+        "input": "/ch/23/send/5/lvl",
+        "output": "/chsend/23/5/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/5/on",
+        "output": "/chsend/23/5/mix_on"
+    },
+    {
+        "input": "/ch/23/send/6/lvl",
+        "output": "/chsend/23/6/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/6/on",
+        "output": "/chsend/23/6/mix_on"
+    },
+    {
+        "input": "/ch/23/send/7/lvl",
+        "output": "/chsend/23/7/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/7/on",
+        "output": "/chsend/23/7/mix_on"
+    },
+    {
+        "input": "/ch/23/send/8/lvl",
+        "output": "/chsend/23/8/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/8/on",
+        "output": "/chsend/23/8/mix_on"
+    },
+    {
+        "input": "/ch/23/send/9/lvl",
+        "output": "/chsend/23/9/mix_fader"
+    },
+    {
+        "input": "/ch/23/send/9/on",
+        "output": "/chsend/23/9/mix_on"
+    },
+    {
+        "input": "/ch/24/col",
+        "output": "/ch/24/config_color"
+    },
+    {
+        "input": "/ch/24/fdr",
+        "output": "/ch/24/mix_fader"
+    },
+    {
+        "input": "/ch/24/in/conn/altgrp",
+        "output": "/ch/24/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/24/in/conn/altin",
+        "output": "/ch/24/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/24/in/conn/grp",
+        "output": "/ch/24/input_conn_grp"
+    },
+    {
+        "input": "/ch/24/in/conn/in",
+        "output": "/ch/24/input_conn_in"
+    },
+    {
+        "input": "/ch/24/in/set/$g",
+        "output": "/ch/24/preamp_gain"
+    },
+    {
+        "input": "/ch/24/in/set/$mode",
+        "output": "/ch/24/input_mode"
+    },
+    {
+        "input": "/ch/24/in/set/$vph",
+        "output": "/ch/24/preamp_phantom"
+    },
+    {
+        "input": "/ch/24/in/set/altsrc",
+        "output": "/ch/24/input_altsrc"
+    },
+    {
+        "input": "/ch/24/in/set/bal",
+        "output": "/ch/24/input_balance"
+    },
+    {
+        "input": "/ch/24/in/set/dly",
+        "output": "/ch/24/input_delay"
+    },
+    {
+        "input": "/ch/24/in/set/dlymode",
+        "output": "/ch/24/input_delay_mode"
+    },
+    {
+        "input": "/ch/24/in/set/dlyon",
+        "output": "/ch/24/input_delay_on"
+    },
+    {
+        "input": "/ch/24/in/set/inv",
+        "output": "/ch/24/input_invert"
+    },
+    {
+        "input": "/ch/24/in/set/srcauto",
+        "output": "/ch/24/input_srcauto"
+    },
+    {
+        "input": "/ch/24/in/set/trim",
+        "output": "/ch/24/input_trim"
+    },
+    {
+        "input": "/ch/24/mute",
+        "output": "/ch/24/mix_on"
+    },
+    {
+        "input": "/ch/24/name",
+        "output": "/ch/24/config_name"
+    },
+    {
+        "input": "/ch/24/send/1/lvl",
+        "output": "/chsend/24/1/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/1/on",
+        "output": "/chsend/24/1/mix_on"
+    },
+    {
+        "input": "/ch/24/send/10/lvl",
+        "output": "/chsend/24/10/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/10/on",
+        "output": "/chsend/24/10/mix_on"
+    },
+    {
+        "input": "/ch/24/send/11/lvl",
+        "output": "/chsend/24/11/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/11/on",
+        "output": "/chsend/24/11/mix_on"
+    },
+    {
+        "input": "/ch/24/send/12/lvl",
+        "output": "/chsend/24/12/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/12/on",
+        "output": "/chsend/24/12/mix_on"
+    },
+    {
+        "input": "/ch/24/send/13/lvl",
+        "output": "/chsend/24/13/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/13/on",
+        "output": "/chsend/24/13/mix_on"
+    },
+    {
+        "input": "/ch/24/send/14/lvl",
+        "output": "/chsend/24/14/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/14/on",
+        "output": "/chsend/24/14/mix_on"
+    },
+    {
+        "input": "/ch/24/send/15/lvl",
+        "output": "/chsend/24/15/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/15/on",
+        "output": "/chsend/24/15/mix_on"
+    },
+    {
+        "input": "/ch/24/send/16/lvl",
+        "output": "/chsend/24/16/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/16/on",
+        "output": "/chsend/24/16/mix_on"
+    },
+    {
+        "input": "/ch/24/send/2/lvl",
+        "output": "/chsend/24/2/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/2/on",
+        "output": "/chsend/24/2/mix_on"
+    },
+    {
+        "input": "/ch/24/send/3/lvl",
+        "output": "/chsend/24/3/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/3/on",
+        "output": "/chsend/24/3/mix_on"
+    },
+    {
+        "input": "/ch/24/send/4/lvl",
+        "output": "/chsend/24/4/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/4/on",
+        "output": "/chsend/24/4/mix_on"
+    },
+    {
+        "input": "/ch/24/send/5/lvl",
+        "output": "/chsend/24/5/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/5/on",
+        "output": "/chsend/24/5/mix_on"
+    },
+    {
+        "input": "/ch/24/send/6/lvl",
+        "output": "/chsend/24/6/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/6/on",
+        "output": "/chsend/24/6/mix_on"
+    },
+    {
+        "input": "/ch/24/send/7/lvl",
+        "output": "/chsend/24/7/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/7/on",
+        "output": "/chsend/24/7/mix_on"
+    },
+    {
+        "input": "/ch/24/send/8/lvl",
+        "output": "/chsend/24/8/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/8/on",
+        "output": "/chsend/24/8/mix_on"
+    },
+    {
+        "input": "/ch/24/send/9/lvl",
+        "output": "/chsend/24/9/mix_fader"
+    },
+    {
+        "input": "/ch/24/send/9/on",
+        "output": "/chsend/24/9/mix_on"
+    },
+    {
+        "input": "/ch/25/col",
+        "output": "/ch/25/config_color"
+    },
+    {
+        "input": "/ch/25/fdr",
+        "output": "/ch/25/mix_fader"
+    },
+    {
+        "input": "/ch/25/in/conn/altgrp",
+        "output": "/ch/25/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/25/in/conn/altin",
+        "output": "/ch/25/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/25/in/conn/grp",
+        "output": "/ch/25/input_conn_grp"
+    },
+    {
+        "input": "/ch/25/in/conn/in",
+        "output": "/ch/25/input_conn_in"
+    },
+    {
+        "input": "/ch/25/in/set/$g",
+        "output": "/ch/25/preamp_gain"
+    },
+    {
+        "input": "/ch/25/in/set/$mode",
+        "output": "/ch/25/input_mode"
+    },
+    {
+        "input": "/ch/25/in/set/$vph",
+        "output": "/ch/25/preamp_phantom"
+    },
+    {
+        "input": "/ch/25/in/set/altsrc",
+        "output": "/ch/25/input_altsrc"
+    },
+    {
+        "input": "/ch/25/in/set/bal",
+        "output": "/ch/25/input_balance"
+    },
+    {
+        "input": "/ch/25/in/set/dly",
+        "output": "/ch/25/input_delay"
+    },
+    {
+        "input": "/ch/25/in/set/dlymode",
+        "output": "/ch/25/input_delay_mode"
+    },
+    {
+        "input": "/ch/25/in/set/dlyon",
+        "output": "/ch/25/input_delay_on"
+    },
+    {
+        "input": "/ch/25/in/set/inv",
+        "output": "/ch/25/input_invert"
+    },
+    {
+        "input": "/ch/25/in/set/srcauto",
+        "output": "/ch/25/input_srcauto"
+    },
+    {
+        "input": "/ch/25/in/set/trim",
+        "output": "/ch/25/input_trim"
+    },
+    {
+        "input": "/ch/25/mute",
+        "output": "/ch/25/mix_on"
+    },
+    {
+        "input": "/ch/25/name",
+        "output": "/ch/25/config_name"
+    },
+    {
+        "input": "/ch/25/send/1/lvl",
+        "output": "/chsend/25/1/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/1/on",
+        "output": "/chsend/25/1/mix_on"
+    },
+    {
+        "input": "/ch/25/send/10/lvl",
+        "output": "/chsend/25/10/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/10/on",
+        "output": "/chsend/25/10/mix_on"
+    },
+    {
+        "input": "/ch/25/send/11/lvl",
+        "output": "/chsend/25/11/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/11/on",
+        "output": "/chsend/25/11/mix_on"
+    },
+    {
+        "input": "/ch/25/send/12/lvl",
+        "output": "/chsend/25/12/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/12/on",
+        "output": "/chsend/25/12/mix_on"
+    },
+    {
+        "input": "/ch/25/send/13/lvl",
+        "output": "/chsend/25/13/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/13/on",
+        "output": "/chsend/25/13/mix_on"
+    },
+    {
+        "input": "/ch/25/send/14/lvl",
+        "output": "/chsend/25/14/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/14/on",
+        "output": "/chsend/25/14/mix_on"
+    },
+    {
+        "input": "/ch/25/send/15/lvl",
+        "output": "/chsend/25/15/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/15/on",
+        "output": "/chsend/25/15/mix_on"
+    },
+    {
+        "input": "/ch/25/send/16/lvl",
+        "output": "/chsend/25/16/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/16/on",
+        "output": "/chsend/25/16/mix_on"
+    },
+    {
+        "input": "/ch/25/send/2/lvl",
+        "output": "/chsend/25/2/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/2/on",
+        "output": "/chsend/25/2/mix_on"
+    },
+    {
+        "input": "/ch/25/send/3/lvl",
+        "output": "/chsend/25/3/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/3/on",
+        "output": "/chsend/25/3/mix_on"
+    },
+    {
+        "input": "/ch/25/send/4/lvl",
+        "output": "/chsend/25/4/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/4/on",
+        "output": "/chsend/25/4/mix_on"
+    },
+    {
+        "input": "/ch/25/send/5/lvl",
+        "output": "/chsend/25/5/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/5/on",
+        "output": "/chsend/25/5/mix_on"
+    },
+    {
+        "input": "/ch/25/send/6/lvl",
+        "output": "/chsend/25/6/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/6/on",
+        "output": "/chsend/25/6/mix_on"
+    },
+    {
+        "input": "/ch/25/send/7/lvl",
+        "output": "/chsend/25/7/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/7/on",
+        "output": "/chsend/25/7/mix_on"
+    },
+    {
+        "input": "/ch/25/send/8/lvl",
+        "output": "/chsend/25/8/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/8/on",
+        "output": "/chsend/25/8/mix_on"
+    },
+    {
+        "input": "/ch/25/send/9/lvl",
+        "output": "/chsend/25/9/mix_fader"
+    },
+    {
+        "input": "/ch/25/send/9/on",
+        "output": "/chsend/25/9/mix_on"
+    },
+    {
+        "input": "/ch/26/col",
+        "output": "/ch/26/config_color"
+    },
+    {
+        "input": "/ch/26/fdr",
+        "output": "/ch/26/mix_fader"
+    },
+    {
+        "input": "/ch/26/in/conn/altgrp",
+        "output": "/ch/26/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/26/in/conn/altin",
+        "output": "/ch/26/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/26/in/conn/grp",
+        "output": "/ch/26/input_conn_grp"
+    },
+    {
+        "input": "/ch/26/in/conn/in",
+        "output": "/ch/26/input_conn_in"
+    },
+    {
+        "input": "/ch/26/in/set/$g",
+        "output": "/ch/26/preamp_gain"
+    },
+    {
+        "input": "/ch/26/in/set/$mode",
+        "output": "/ch/26/input_mode"
+    },
+    {
+        "input": "/ch/26/in/set/$vph",
+        "output": "/ch/26/preamp_phantom"
+    },
+    {
+        "input": "/ch/26/in/set/altsrc",
+        "output": "/ch/26/input_altsrc"
+    },
+    {
+        "input": "/ch/26/in/set/bal",
+        "output": "/ch/26/input_balance"
+    },
+    {
+        "input": "/ch/26/in/set/dly",
+        "output": "/ch/26/input_delay"
+    },
+    {
+        "input": "/ch/26/in/set/dlymode",
+        "output": "/ch/26/input_delay_mode"
+    },
+    {
+        "input": "/ch/26/in/set/dlyon",
+        "output": "/ch/26/input_delay_on"
+    },
+    {
+        "input": "/ch/26/in/set/inv",
+        "output": "/ch/26/input_invert"
+    },
+    {
+        "input": "/ch/26/in/set/srcauto",
+        "output": "/ch/26/input_srcauto"
+    },
+    {
+        "input": "/ch/26/in/set/trim",
+        "output": "/ch/26/input_trim"
+    },
+    {
+        "input": "/ch/26/mute",
+        "output": "/ch/26/mix_on"
+    },
+    {
+        "input": "/ch/26/name",
+        "output": "/ch/26/config_name"
+    },
+    {
+        "input": "/ch/26/send/1/lvl",
+        "output": "/chsend/26/1/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/1/on",
+        "output": "/chsend/26/1/mix_on"
+    },
+    {
+        "input": "/ch/26/send/10/lvl",
+        "output": "/chsend/26/10/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/10/on",
+        "output": "/chsend/26/10/mix_on"
+    },
+    {
+        "input": "/ch/26/send/11/lvl",
+        "output": "/chsend/26/11/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/11/on",
+        "output": "/chsend/26/11/mix_on"
+    },
+    {
+        "input": "/ch/26/send/12/lvl",
+        "output": "/chsend/26/12/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/12/on",
+        "output": "/chsend/26/12/mix_on"
+    },
+    {
+        "input": "/ch/26/send/13/lvl",
+        "output": "/chsend/26/13/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/13/on",
+        "output": "/chsend/26/13/mix_on"
+    },
+    {
+        "input": "/ch/26/send/14/lvl",
+        "output": "/chsend/26/14/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/14/on",
+        "output": "/chsend/26/14/mix_on"
+    },
+    {
+        "input": "/ch/26/send/15/lvl",
+        "output": "/chsend/26/15/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/15/on",
+        "output": "/chsend/26/15/mix_on"
+    },
+    {
+        "input": "/ch/26/send/16/lvl",
+        "output": "/chsend/26/16/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/16/on",
+        "output": "/chsend/26/16/mix_on"
+    },
+    {
+        "input": "/ch/26/send/2/lvl",
+        "output": "/chsend/26/2/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/2/on",
+        "output": "/chsend/26/2/mix_on"
+    },
+    {
+        "input": "/ch/26/send/3/lvl",
+        "output": "/chsend/26/3/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/3/on",
+        "output": "/chsend/26/3/mix_on"
+    },
+    {
+        "input": "/ch/26/send/4/lvl",
+        "output": "/chsend/26/4/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/4/on",
+        "output": "/chsend/26/4/mix_on"
+    },
+    {
+        "input": "/ch/26/send/5/lvl",
+        "output": "/chsend/26/5/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/5/on",
+        "output": "/chsend/26/5/mix_on"
+    },
+    {
+        "input": "/ch/26/send/6/lvl",
+        "output": "/chsend/26/6/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/6/on",
+        "output": "/chsend/26/6/mix_on"
+    },
+    {
+        "input": "/ch/26/send/7/lvl",
+        "output": "/chsend/26/7/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/7/on",
+        "output": "/chsend/26/7/mix_on"
+    },
+    {
+        "input": "/ch/26/send/8/lvl",
+        "output": "/chsend/26/8/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/8/on",
+        "output": "/chsend/26/8/mix_on"
+    },
+    {
+        "input": "/ch/26/send/9/lvl",
+        "output": "/chsend/26/9/mix_fader"
+    },
+    {
+        "input": "/ch/26/send/9/on",
+        "output": "/chsend/26/9/mix_on"
+    },
+    {
+        "input": "/ch/27/col",
+        "output": "/ch/27/config_color"
+    },
+    {
+        "input": "/ch/27/fdr",
+        "output": "/ch/27/mix_fader"
+    },
+    {
+        "input": "/ch/27/in/conn/altgrp",
+        "output": "/ch/27/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/27/in/conn/altin",
+        "output": "/ch/27/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/27/in/conn/grp",
+        "output": "/ch/27/input_conn_grp"
+    },
+    {
+        "input": "/ch/27/in/conn/in",
+        "output": "/ch/27/input_conn_in"
+    },
+    {
+        "input": "/ch/27/in/set/$g",
+        "output": "/ch/27/preamp_gain"
+    },
+    {
+        "input": "/ch/27/in/set/$mode",
+        "output": "/ch/27/input_mode"
+    },
+    {
+        "input": "/ch/27/in/set/$vph",
+        "output": "/ch/27/preamp_phantom"
+    },
+    {
+        "input": "/ch/27/in/set/altsrc",
+        "output": "/ch/27/input_altsrc"
+    },
+    {
+        "input": "/ch/27/in/set/bal",
+        "output": "/ch/27/input_balance"
+    },
+    {
+        "input": "/ch/27/in/set/dly",
+        "output": "/ch/27/input_delay"
+    },
+    {
+        "input": "/ch/27/in/set/dlymode",
+        "output": "/ch/27/input_delay_mode"
+    },
+    {
+        "input": "/ch/27/in/set/dlyon",
+        "output": "/ch/27/input_delay_on"
+    },
+    {
+        "input": "/ch/27/in/set/inv",
+        "output": "/ch/27/input_invert"
+    },
+    {
+        "input": "/ch/27/in/set/srcauto",
+        "output": "/ch/27/input_srcauto"
+    },
+    {
+        "input": "/ch/27/in/set/trim",
+        "output": "/ch/27/input_trim"
+    },
+    {
+        "input": "/ch/27/mute",
+        "output": "/ch/27/mix_on"
+    },
+    {
+        "input": "/ch/27/name",
+        "output": "/ch/27/config_name"
+    },
+    {
+        "input": "/ch/27/send/1/lvl",
+        "output": "/chsend/27/1/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/1/on",
+        "output": "/chsend/27/1/mix_on"
+    },
+    {
+        "input": "/ch/27/send/10/lvl",
+        "output": "/chsend/27/10/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/10/on",
+        "output": "/chsend/27/10/mix_on"
+    },
+    {
+        "input": "/ch/27/send/11/lvl",
+        "output": "/chsend/27/11/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/11/on",
+        "output": "/chsend/27/11/mix_on"
+    },
+    {
+        "input": "/ch/27/send/12/lvl",
+        "output": "/chsend/27/12/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/12/on",
+        "output": "/chsend/27/12/mix_on"
+    },
+    {
+        "input": "/ch/27/send/13/lvl",
+        "output": "/chsend/27/13/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/13/on",
+        "output": "/chsend/27/13/mix_on"
+    },
+    {
+        "input": "/ch/27/send/14/lvl",
+        "output": "/chsend/27/14/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/14/on",
+        "output": "/chsend/27/14/mix_on"
+    },
+    {
+        "input": "/ch/27/send/15/lvl",
+        "output": "/chsend/27/15/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/15/on",
+        "output": "/chsend/27/15/mix_on"
+    },
+    {
+        "input": "/ch/27/send/16/lvl",
+        "output": "/chsend/27/16/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/16/on",
+        "output": "/chsend/27/16/mix_on"
+    },
+    {
+        "input": "/ch/27/send/2/lvl",
+        "output": "/chsend/27/2/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/2/on",
+        "output": "/chsend/27/2/mix_on"
+    },
+    {
+        "input": "/ch/27/send/3/lvl",
+        "output": "/chsend/27/3/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/3/on",
+        "output": "/chsend/27/3/mix_on"
+    },
+    {
+        "input": "/ch/27/send/4/lvl",
+        "output": "/chsend/27/4/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/4/on",
+        "output": "/chsend/27/4/mix_on"
+    },
+    {
+        "input": "/ch/27/send/5/lvl",
+        "output": "/chsend/27/5/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/5/on",
+        "output": "/chsend/27/5/mix_on"
+    },
+    {
+        "input": "/ch/27/send/6/lvl",
+        "output": "/chsend/27/6/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/6/on",
+        "output": "/chsend/27/6/mix_on"
+    },
+    {
+        "input": "/ch/27/send/7/lvl",
+        "output": "/chsend/27/7/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/7/on",
+        "output": "/chsend/27/7/mix_on"
+    },
+    {
+        "input": "/ch/27/send/8/lvl",
+        "output": "/chsend/27/8/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/8/on",
+        "output": "/chsend/27/8/mix_on"
+    },
+    {
+        "input": "/ch/27/send/9/lvl",
+        "output": "/chsend/27/9/mix_fader"
+    },
+    {
+        "input": "/ch/27/send/9/on",
+        "output": "/chsend/27/9/mix_on"
+    },
+    {
+        "input": "/ch/28/col",
+        "output": "/ch/28/config_color"
+    },
+    {
+        "input": "/ch/28/fdr",
+        "output": "/ch/28/mix_fader"
+    },
+    {
+        "input": "/ch/28/in/conn/altgrp",
+        "output": "/ch/28/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/28/in/conn/altin",
+        "output": "/ch/28/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/28/in/conn/grp",
+        "output": "/ch/28/input_conn_grp"
+    },
+    {
+        "input": "/ch/28/in/conn/in",
+        "output": "/ch/28/input_conn_in"
+    },
+    {
+        "input": "/ch/28/in/set/$g",
+        "output": "/ch/28/preamp_gain"
+    },
+    {
+        "input": "/ch/28/in/set/$mode",
+        "output": "/ch/28/input_mode"
+    },
+    {
+        "input": "/ch/28/in/set/$vph",
+        "output": "/ch/28/preamp_phantom"
+    },
+    {
+        "input": "/ch/28/in/set/altsrc",
+        "output": "/ch/28/input_altsrc"
+    },
+    {
+        "input": "/ch/28/in/set/bal",
+        "output": "/ch/28/input_balance"
+    },
+    {
+        "input": "/ch/28/in/set/dly",
+        "output": "/ch/28/input_delay"
+    },
+    {
+        "input": "/ch/28/in/set/dlymode",
+        "output": "/ch/28/input_delay_mode"
+    },
+    {
+        "input": "/ch/28/in/set/dlyon",
+        "output": "/ch/28/input_delay_on"
+    },
+    {
+        "input": "/ch/28/in/set/inv",
+        "output": "/ch/28/input_invert"
+    },
+    {
+        "input": "/ch/28/in/set/srcauto",
+        "output": "/ch/28/input_srcauto"
+    },
+    {
+        "input": "/ch/28/in/set/trim",
+        "output": "/ch/28/input_trim"
+    },
+    {
+        "input": "/ch/28/mute",
+        "output": "/ch/28/mix_on"
+    },
+    {
+        "input": "/ch/28/name",
+        "output": "/ch/28/config_name"
+    },
+    {
+        "input": "/ch/28/send/1/lvl",
+        "output": "/chsend/28/1/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/1/on",
+        "output": "/chsend/28/1/mix_on"
+    },
+    {
+        "input": "/ch/28/send/10/lvl",
+        "output": "/chsend/28/10/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/10/on",
+        "output": "/chsend/28/10/mix_on"
+    },
+    {
+        "input": "/ch/28/send/11/lvl",
+        "output": "/chsend/28/11/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/11/on",
+        "output": "/chsend/28/11/mix_on"
+    },
+    {
+        "input": "/ch/28/send/12/lvl",
+        "output": "/chsend/28/12/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/12/on",
+        "output": "/chsend/28/12/mix_on"
+    },
+    {
+        "input": "/ch/28/send/13/lvl",
+        "output": "/chsend/28/13/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/13/on",
+        "output": "/chsend/28/13/mix_on"
+    },
+    {
+        "input": "/ch/28/send/14/lvl",
+        "output": "/chsend/28/14/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/14/on",
+        "output": "/chsend/28/14/mix_on"
+    },
+    {
+        "input": "/ch/28/send/15/lvl",
+        "output": "/chsend/28/15/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/15/on",
+        "output": "/chsend/28/15/mix_on"
+    },
+    {
+        "input": "/ch/28/send/16/lvl",
+        "output": "/chsend/28/16/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/16/on",
+        "output": "/chsend/28/16/mix_on"
+    },
+    {
+        "input": "/ch/28/send/2/lvl",
+        "output": "/chsend/28/2/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/2/on",
+        "output": "/chsend/28/2/mix_on"
+    },
+    {
+        "input": "/ch/28/send/3/lvl",
+        "output": "/chsend/28/3/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/3/on",
+        "output": "/chsend/28/3/mix_on"
+    },
+    {
+        "input": "/ch/28/send/4/lvl",
+        "output": "/chsend/28/4/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/4/on",
+        "output": "/chsend/28/4/mix_on"
+    },
+    {
+        "input": "/ch/28/send/5/lvl",
+        "output": "/chsend/28/5/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/5/on",
+        "output": "/chsend/28/5/mix_on"
+    },
+    {
+        "input": "/ch/28/send/6/lvl",
+        "output": "/chsend/28/6/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/6/on",
+        "output": "/chsend/28/6/mix_on"
+    },
+    {
+        "input": "/ch/28/send/7/lvl",
+        "output": "/chsend/28/7/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/7/on",
+        "output": "/chsend/28/7/mix_on"
+    },
+    {
+        "input": "/ch/28/send/8/lvl",
+        "output": "/chsend/28/8/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/8/on",
+        "output": "/chsend/28/8/mix_on"
+    },
+    {
+        "input": "/ch/28/send/9/lvl",
+        "output": "/chsend/28/9/mix_fader"
+    },
+    {
+        "input": "/ch/28/send/9/on",
+        "output": "/chsend/28/9/mix_on"
+    },
+    {
+        "input": "/ch/29/col",
+        "output": "/ch/29/config_color"
+    },
+    {
+        "input": "/ch/29/fdr",
+        "output": "/ch/29/mix_fader"
+    },
+    {
+        "input": "/ch/29/in/conn/altgrp",
+        "output": "/ch/29/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/29/in/conn/altin",
+        "output": "/ch/29/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/29/in/conn/grp",
+        "output": "/ch/29/input_conn_grp"
+    },
+    {
+        "input": "/ch/29/in/conn/in",
+        "output": "/ch/29/input_conn_in"
+    },
+    {
+        "input": "/ch/29/in/set/$g",
+        "output": "/ch/29/preamp_gain"
+    },
+    {
+        "input": "/ch/29/in/set/$mode",
+        "output": "/ch/29/input_mode"
+    },
+    {
+        "input": "/ch/29/in/set/$vph",
+        "output": "/ch/29/preamp_phantom"
+    },
+    {
+        "input": "/ch/29/in/set/altsrc",
+        "output": "/ch/29/input_altsrc"
+    },
+    {
+        "input": "/ch/29/in/set/bal",
+        "output": "/ch/29/input_balance"
+    },
+    {
+        "input": "/ch/29/in/set/dly",
+        "output": "/ch/29/input_delay"
+    },
+    {
+        "input": "/ch/29/in/set/dlymode",
+        "output": "/ch/29/input_delay_mode"
+    },
+    {
+        "input": "/ch/29/in/set/dlyon",
+        "output": "/ch/29/input_delay_on"
+    },
+    {
+        "input": "/ch/29/in/set/inv",
+        "output": "/ch/29/input_invert"
+    },
+    {
+        "input": "/ch/29/in/set/srcauto",
+        "output": "/ch/29/input_srcauto"
+    },
+    {
+        "input": "/ch/29/in/set/trim",
+        "output": "/ch/29/input_trim"
+    },
+    {
+        "input": "/ch/29/mute",
+        "output": "/ch/29/mix_on"
+    },
+    {
+        "input": "/ch/29/name",
+        "output": "/ch/29/config_name"
+    },
+    {
+        "input": "/ch/29/send/1/lvl",
+        "output": "/chsend/29/1/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/1/on",
+        "output": "/chsend/29/1/mix_on"
+    },
+    {
+        "input": "/ch/29/send/10/lvl",
+        "output": "/chsend/29/10/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/10/on",
+        "output": "/chsend/29/10/mix_on"
+    },
+    {
+        "input": "/ch/29/send/11/lvl",
+        "output": "/chsend/29/11/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/11/on",
+        "output": "/chsend/29/11/mix_on"
+    },
+    {
+        "input": "/ch/29/send/12/lvl",
+        "output": "/chsend/29/12/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/12/on",
+        "output": "/chsend/29/12/mix_on"
+    },
+    {
+        "input": "/ch/29/send/13/lvl",
+        "output": "/chsend/29/13/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/13/on",
+        "output": "/chsend/29/13/mix_on"
+    },
+    {
+        "input": "/ch/29/send/14/lvl",
+        "output": "/chsend/29/14/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/14/on",
+        "output": "/chsend/29/14/mix_on"
+    },
+    {
+        "input": "/ch/29/send/15/lvl",
+        "output": "/chsend/29/15/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/15/on",
+        "output": "/chsend/29/15/mix_on"
+    },
+    {
+        "input": "/ch/29/send/16/lvl",
+        "output": "/chsend/29/16/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/16/on",
+        "output": "/chsend/29/16/mix_on"
+    },
+    {
+        "input": "/ch/29/send/2/lvl",
+        "output": "/chsend/29/2/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/2/on",
+        "output": "/chsend/29/2/mix_on"
+    },
+    {
+        "input": "/ch/29/send/3/lvl",
+        "output": "/chsend/29/3/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/3/on",
+        "output": "/chsend/29/3/mix_on"
+    },
+    {
+        "input": "/ch/29/send/4/lvl",
+        "output": "/chsend/29/4/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/4/on",
+        "output": "/chsend/29/4/mix_on"
+    },
+    {
+        "input": "/ch/29/send/5/lvl",
+        "output": "/chsend/29/5/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/5/on",
+        "output": "/chsend/29/5/mix_on"
+    },
+    {
+        "input": "/ch/29/send/6/lvl",
+        "output": "/chsend/29/6/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/6/on",
+        "output": "/chsend/29/6/mix_on"
+    },
+    {
+        "input": "/ch/29/send/7/lvl",
+        "output": "/chsend/29/7/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/7/on",
+        "output": "/chsend/29/7/mix_on"
+    },
+    {
+        "input": "/ch/29/send/8/lvl",
+        "output": "/chsend/29/8/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/8/on",
+        "output": "/chsend/29/8/mix_on"
+    },
+    {
+        "input": "/ch/29/send/9/lvl",
+        "output": "/chsend/29/9/mix_fader"
+    },
+    {
+        "input": "/ch/29/send/9/on",
+        "output": "/chsend/29/9/mix_on"
+    },
+    {
+        "input": "/ch/3/col",
+        "output": "/ch/3/config_color"
+    },
+    {
+        "input": "/ch/3/fdr",
+        "output": "/ch/3/mix_fader"
+    },
+    {
+        "input": "/ch/3/in/conn/altgrp",
+        "output": "/ch/3/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/3/in/conn/altin",
+        "output": "/ch/3/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/3/in/conn/grp",
+        "output": "/ch/3/input_conn_grp"
+    },
+    {
+        "input": "/ch/3/in/conn/in",
+        "output": "/ch/3/input_conn_in"
+    },
+    {
+        "input": "/ch/3/in/set/$g",
+        "output": "/ch/3/preamp_gain"
+    },
+    {
+        "input": "/ch/3/in/set/$mode",
+        "output": "/ch/3/input_mode"
+    },
+    {
+        "input": "/ch/3/in/set/$vph",
+        "output": "/ch/3/preamp_phantom"
+    },
+    {
+        "input": "/ch/3/in/set/altsrc",
+        "output": "/ch/3/input_altsrc"
+    },
+    {
+        "input": "/ch/3/in/set/bal",
+        "output": "/ch/3/input_balance"
+    },
+    {
+        "input": "/ch/3/in/set/dly",
+        "output": "/ch/3/input_delay"
+    },
+    {
+        "input": "/ch/3/in/set/dlymode",
+        "output": "/ch/3/input_delay_mode"
+    },
+    {
+        "input": "/ch/3/in/set/dlyon",
+        "output": "/ch/3/input_delay_on"
+    },
+    {
+        "input": "/ch/3/in/set/inv",
+        "output": "/ch/3/input_invert"
+    },
+    {
+        "input": "/ch/3/in/set/srcauto",
+        "output": "/ch/3/input_srcauto"
+    },
+    {
+        "input": "/ch/3/in/set/trim",
+        "output": "/ch/3/input_trim"
+    },
+    {
+        "input": "/ch/3/mute",
+        "output": "/ch/3/mix_on"
+    },
+    {
+        "input": "/ch/3/name",
+        "output": "/ch/3/config_name"
+    },
+    {
+        "input": "/ch/3/send/1/lvl",
+        "output": "/chsend/3/1/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/1/on",
+        "output": "/chsend/3/1/mix_on"
+    },
+    {
+        "input": "/ch/3/send/10/lvl",
+        "output": "/chsend/3/10/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/10/on",
+        "output": "/chsend/3/10/mix_on"
+    },
+    {
+        "input": "/ch/3/send/11/lvl",
+        "output": "/chsend/3/11/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/11/on",
+        "output": "/chsend/3/11/mix_on"
+    },
+    {
+        "input": "/ch/3/send/12/lvl",
+        "output": "/chsend/3/12/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/12/on",
+        "output": "/chsend/3/12/mix_on"
+    },
+    {
+        "input": "/ch/3/send/13/lvl",
+        "output": "/chsend/3/13/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/13/on",
+        "output": "/chsend/3/13/mix_on"
+    },
+    {
+        "input": "/ch/3/send/14/lvl",
+        "output": "/chsend/3/14/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/14/on",
+        "output": "/chsend/3/14/mix_on"
+    },
+    {
+        "input": "/ch/3/send/15/lvl",
+        "output": "/chsend/3/15/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/15/on",
+        "output": "/chsend/3/15/mix_on"
+    },
+    {
+        "input": "/ch/3/send/16/lvl",
+        "output": "/chsend/3/16/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/16/on",
+        "output": "/chsend/3/16/mix_on"
+    },
+    {
+        "input": "/ch/3/send/2/lvl",
+        "output": "/chsend/3/2/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/2/on",
+        "output": "/chsend/3/2/mix_on"
+    },
+    {
+        "input": "/ch/3/send/3/lvl",
+        "output": "/chsend/3/3/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/3/on",
+        "output": "/chsend/3/3/mix_on"
+    },
+    {
+        "input": "/ch/3/send/4/lvl",
+        "output": "/chsend/3/4/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/4/on",
+        "output": "/chsend/3/4/mix_on"
+    },
+    {
+        "input": "/ch/3/send/5/lvl",
+        "output": "/chsend/3/5/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/5/on",
+        "output": "/chsend/3/5/mix_on"
+    },
+    {
+        "input": "/ch/3/send/6/lvl",
+        "output": "/chsend/3/6/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/6/on",
+        "output": "/chsend/3/6/mix_on"
+    },
+    {
+        "input": "/ch/3/send/7/lvl",
+        "output": "/chsend/3/7/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/7/on",
+        "output": "/chsend/3/7/mix_on"
+    },
+    {
+        "input": "/ch/3/send/8/lvl",
+        "output": "/chsend/3/8/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/8/on",
+        "output": "/chsend/3/8/mix_on"
+    },
+    {
+        "input": "/ch/3/send/9/lvl",
+        "output": "/chsend/3/9/mix_fader"
+    },
+    {
+        "input": "/ch/3/send/9/on",
+        "output": "/chsend/3/9/mix_on"
+    },
+    {
+        "input": "/ch/30/col",
+        "output": "/ch/30/config_color"
+    },
+    {
+        "input": "/ch/30/fdr",
+        "output": "/ch/30/mix_fader"
+    },
+    {
+        "input": "/ch/30/in/conn/altgrp",
+        "output": "/ch/30/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/30/in/conn/altin",
+        "output": "/ch/30/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/30/in/conn/grp",
+        "output": "/ch/30/input_conn_grp"
+    },
+    {
+        "input": "/ch/30/in/conn/in",
+        "output": "/ch/30/input_conn_in"
+    },
+    {
+        "input": "/ch/30/in/set/$g",
+        "output": "/ch/30/preamp_gain"
+    },
+    {
+        "input": "/ch/30/in/set/$mode",
+        "output": "/ch/30/input_mode"
+    },
+    {
+        "input": "/ch/30/in/set/$vph",
+        "output": "/ch/30/preamp_phantom"
+    },
+    {
+        "input": "/ch/30/in/set/altsrc",
+        "output": "/ch/30/input_altsrc"
+    },
+    {
+        "input": "/ch/30/in/set/bal",
+        "output": "/ch/30/input_balance"
+    },
+    {
+        "input": "/ch/30/in/set/dly",
+        "output": "/ch/30/input_delay"
+    },
+    {
+        "input": "/ch/30/in/set/dlymode",
+        "output": "/ch/30/input_delay_mode"
+    },
+    {
+        "input": "/ch/30/in/set/dlyon",
+        "output": "/ch/30/input_delay_on"
+    },
+    {
+        "input": "/ch/30/in/set/inv",
+        "output": "/ch/30/input_invert"
+    },
+    {
+        "input": "/ch/30/in/set/srcauto",
+        "output": "/ch/30/input_srcauto"
+    },
+    {
+        "input": "/ch/30/in/set/trim",
+        "output": "/ch/30/input_trim"
+    },
+    {
+        "input": "/ch/30/mute",
+        "output": "/ch/30/mix_on"
+    },
+    {
+        "input": "/ch/30/name",
+        "output": "/ch/30/config_name"
+    },
+    {
+        "input": "/ch/30/send/1/lvl",
+        "output": "/chsend/30/1/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/1/on",
+        "output": "/chsend/30/1/mix_on"
+    },
+    {
+        "input": "/ch/30/send/10/lvl",
+        "output": "/chsend/30/10/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/10/on",
+        "output": "/chsend/30/10/mix_on"
+    },
+    {
+        "input": "/ch/30/send/11/lvl",
+        "output": "/chsend/30/11/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/11/on",
+        "output": "/chsend/30/11/mix_on"
+    },
+    {
+        "input": "/ch/30/send/12/lvl",
+        "output": "/chsend/30/12/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/12/on",
+        "output": "/chsend/30/12/mix_on"
+    },
+    {
+        "input": "/ch/30/send/13/lvl",
+        "output": "/chsend/30/13/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/13/on",
+        "output": "/chsend/30/13/mix_on"
+    },
+    {
+        "input": "/ch/30/send/14/lvl",
+        "output": "/chsend/30/14/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/14/on",
+        "output": "/chsend/30/14/mix_on"
+    },
+    {
+        "input": "/ch/30/send/15/lvl",
+        "output": "/chsend/30/15/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/15/on",
+        "output": "/chsend/30/15/mix_on"
+    },
+    {
+        "input": "/ch/30/send/16/lvl",
+        "output": "/chsend/30/16/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/16/on",
+        "output": "/chsend/30/16/mix_on"
+    },
+    {
+        "input": "/ch/30/send/2/lvl",
+        "output": "/chsend/30/2/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/2/on",
+        "output": "/chsend/30/2/mix_on"
+    },
+    {
+        "input": "/ch/30/send/3/lvl",
+        "output": "/chsend/30/3/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/3/on",
+        "output": "/chsend/30/3/mix_on"
+    },
+    {
+        "input": "/ch/30/send/4/lvl",
+        "output": "/chsend/30/4/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/4/on",
+        "output": "/chsend/30/4/mix_on"
+    },
+    {
+        "input": "/ch/30/send/5/lvl",
+        "output": "/chsend/30/5/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/5/on",
+        "output": "/chsend/30/5/mix_on"
+    },
+    {
+        "input": "/ch/30/send/6/lvl",
+        "output": "/chsend/30/6/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/6/on",
+        "output": "/chsend/30/6/mix_on"
+    },
+    {
+        "input": "/ch/30/send/7/lvl",
+        "output": "/chsend/30/7/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/7/on",
+        "output": "/chsend/30/7/mix_on"
+    },
+    {
+        "input": "/ch/30/send/8/lvl",
+        "output": "/chsend/30/8/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/8/on",
+        "output": "/chsend/30/8/mix_on"
+    },
+    {
+        "input": "/ch/30/send/9/lvl",
+        "output": "/chsend/30/9/mix_fader"
+    },
+    {
+        "input": "/ch/30/send/9/on",
+        "output": "/chsend/30/9/mix_on"
+    },
+    {
+        "input": "/ch/31/col",
+        "output": "/ch/31/config_color"
+    },
+    {
+        "input": "/ch/31/fdr",
+        "output": "/ch/31/mix_fader"
+    },
+    {
+        "input": "/ch/31/in/conn/altgrp",
+        "output": "/ch/31/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/31/in/conn/altin",
+        "output": "/ch/31/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/31/in/conn/grp",
+        "output": "/ch/31/input_conn_grp"
+    },
+    {
+        "input": "/ch/31/in/conn/in",
+        "output": "/ch/31/input_conn_in"
+    },
+    {
+        "input": "/ch/31/in/set/$g",
+        "output": "/ch/31/preamp_gain"
+    },
+    {
+        "input": "/ch/31/in/set/$mode",
+        "output": "/ch/31/input_mode"
+    },
+    {
+        "input": "/ch/31/in/set/$vph",
+        "output": "/ch/31/preamp_phantom"
+    },
+    {
+        "input": "/ch/31/in/set/altsrc",
+        "output": "/ch/31/input_altsrc"
+    },
+    {
+        "input": "/ch/31/in/set/bal",
+        "output": "/ch/31/input_balance"
+    },
+    {
+        "input": "/ch/31/in/set/dly",
+        "output": "/ch/31/input_delay"
+    },
+    {
+        "input": "/ch/31/in/set/dlymode",
+        "output": "/ch/31/input_delay_mode"
+    },
+    {
+        "input": "/ch/31/in/set/dlyon",
+        "output": "/ch/31/input_delay_on"
+    },
+    {
+        "input": "/ch/31/in/set/inv",
+        "output": "/ch/31/input_invert"
+    },
+    {
+        "input": "/ch/31/in/set/srcauto",
+        "output": "/ch/31/input_srcauto"
+    },
+    {
+        "input": "/ch/31/in/set/trim",
+        "output": "/ch/31/input_trim"
+    },
+    {
+        "input": "/ch/31/mute",
+        "output": "/ch/31/mix_on"
+    },
+    {
+        "input": "/ch/31/name",
+        "output": "/ch/31/config_name"
+    },
+    {
+        "input": "/ch/31/send/1/lvl",
+        "output": "/chsend/31/1/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/1/on",
+        "output": "/chsend/31/1/mix_on"
+    },
+    {
+        "input": "/ch/31/send/10/lvl",
+        "output": "/chsend/31/10/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/10/on",
+        "output": "/chsend/31/10/mix_on"
+    },
+    {
+        "input": "/ch/31/send/11/lvl",
+        "output": "/chsend/31/11/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/11/on",
+        "output": "/chsend/31/11/mix_on"
+    },
+    {
+        "input": "/ch/31/send/12/lvl",
+        "output": "/chsend/31/12/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/12/on",
+        "output": "/chsend/31/12/mix_on"
+    },
+    {
+        "input": "/ch/31/send/13/lvl",
+        "output": "/chsend/31/13/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/13/on",
+        "output": "/chsend/31/13/mix_on"
+    },
+    {
+        "input": "/ch/31/send/14/lvl",
+        "output": "/chsend/31/14/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/14/on",
+        "output": "/chsend/31/14/mix_on"
+    },
+    {
+        "input": "/ch/31/send/15/lvl",
+        "output": "/chsend/31/15/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/15/on",
+        "output": "/chsend/31/15/mix_on"
+    },
+    {
+        "input": "/ch/31/send/16/lvl",
+        "output": "/chsend/31/16/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/16/on",
+        "output": "/chsend/31/16/mix_on"
+    },
+    {
+        "input": "/ch/31/send/2/lvl",
+        "output": "/chsend/31/2/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/2/on",
+        "output": "/chsend/31/2/mix_on"
+    },
+    {
+        "input": "/ch/31/send/3/lvl",
+        "output": "/chsend/31/3/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/3/on",
+        "output": "/chsend/31/3/mix_on"
+    },
+    {
+        "input": "/ch/31/send/4/lvl",
+        "output": "/chsend/31/4/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/4/on",
+        "output": "/chsend/31/4/mix_on"
+    },
+    {
+        "input": "/ch/31/send/5/lvl",
+        "output": "/chsend/31/5/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/5/on",
+        "output": "/chsend/31/5/mix_on"
+    },
+    {
+        "input": "/ch/31/send/6/lvl",
+        "output": "/chsend/31/6/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/6/on",
+        "output": "/chsend/31/6/mix_on"
+    },
+    {
+        "input": "/ch/31/send/7/lvl",
+        "output": "/chsend/31/7/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/7/on",
+        "output": "/chsend/31/7/mix_on"
+    },
+    {
+        "input": "/ch/31/send/8/lvl",
+        "output": "/chsend/31/8/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/8/on",
+        "output": "/chsend/31/8/mix_on"
+    },
+    {
+        "input": "/ch/31/send/9/lvl",
+        "output": "/chsend/31/9/mix_fader"
+    },
+    {
+        "input": "/ch/31/send/9/on",
+        "output": "/chsend/31/9/mix_on"
+    },
+    {
+        "input": "/ch/32/col",
+        "output": "/ch/32/config_color"
+    },
+    {
+        "input": "/ch/32/fdr",
+        "output": "/ch/32/mix_fader"
+    },
+    {
+        "input": "/ch/32/in/conn/altgrp",
+        "output": "/ch/32/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/32/in/conn/altin",
+        "output": "/ch/32/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/32/in/conn/grp",
+        "output": "/ch/32/input_conn_grp"
+    },
+    {
+        "input": "/ch/32/in/conn/in",
+        "output": "/ch/32/input_conn_in"
+    },
+    {
+        "input": "/ch/32/in/set/$g",
+        "output": "/ch/32/preamp_gain"
+    },
+    {
+        "input": "/ch/32/in/set/$mode",
+        "output": "/ch/32/input_mode"
+    },
+    {
+        "input": "/ch/32/in/set/$vph",
+        "output": "/ch/32/preamp_phantom"
+    },
+    {
+        "input": "/ch/32/in/set/altsrc",
+        "output": "/ch/32/input_altsrc"
+    },
+    {
+        "input": "/ch/32/in/set/bal",
+        "output": "/ch/32/input_balance"
+    },
+    {
+        "input": "/ch/32/in/set/dly",
+        "output": "/ch/32/input_delay"
+    },
+    {
+        "input": "/ch/32/in/set/dlymode",
+        "output": "/ch/32/input_delay_mode"
+    },
+    {
+        "input": "/ch/32/in/set/dlyon",
+        "output": "/ch/32/input_delay_on"
+    },
+    {
+        "input": "/ch/32/in/set/inv",
+        "output": "/ch/32/input_invert"
+    },
+    {
+        "input": "/ch/32/in/set/srcauto",
+        "output": "/ch/32/input_srcauto"
+    },
+    {
+        "input": "/ch/32/in/set/trim",
+        "output": "/ch/32/input_trim"
+    },
+    {
+        "input": "/ch/32/mute",
+        "output": "/ch/32/mix_on"
+    },
+    {
+        "input": "/ch/32/name",
+        "output": "/ch/32/config_name"
+    },
+    {
+        "input": "/ch/32/send/1/lvl",
+        "output": "/chsend/32/1/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/1/on",
+        "output": "/chsend/32/1/mix_on"
+    },
+    {
+        "input": "/ch/32/send/10/lvl",
+        "output": "/chsend/32/10/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/10/on",
+        "output": "/chsend/32/10/mix_on"
+    },
+    {
+        "input": "/ch/32/send/11/lvl",
+        "output": "/chsend/32/11/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/11/on",
+        "output": "/chsend/32/11/mix_on"
+    },
+    {
+        "input": "/ch/32/send/12/lvl",
+        "output": "/chsend/32/12/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/12/on",
+        "output": "/chsend/32/12/mix_on"
+    },
+    {
+        "input": "/ch/32/send/13/lvl",
+        "output": "/chsend/32/13/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/13/on",
+        "output": "/chsend/32/13/mix_on"
+    },
+    {
+        "input": "/ch/32/send/14/lvl",
+        "output": "/chsend/32/14/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/14/on",
+        "output": "/chsend/32/14/mix_on"
+    },
+    {
+        "input": "/ch/32/send/15/lvl",
+        "output": "/chsend/32/15/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/15/on",
+        "output": "/chsend/32/15/mix_on"
+    },
+    {
+        "input": "/ch/32/send/16/lvl",
+        "output": "/chsend/32/16/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/16/on",
+        "output": "/chsend/32/16/mix_on"
+    },
+    {
+        "input": "/ch/32/send/2/lvl",
+        "output": "/chsend/32/2/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/2/on",
+        "output": "/chsend/32/2/mix_on"
+    },
+    {
+        "input": "/ch/32/send/3/lvl",
+        "output": "/chsend/32/3/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/3/on",
+        "output": "/chsend/32/3/mix_on"
+    },
+    {
+        "input": "/ch/32/send/4/lvl",
+        "output": "/chsend/32/4/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/4/on",
+        "output": "/chsend/32/4/mix_on"
+    },
+    {
+        "input": "/ch/32/send/5/lvl",
+        "output": "/chsend/32/5/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/5/on",
+        "output": "/chsend/32/5/mix_on"
+    },
+    {
+        "input": "/ch/32/send/6/lvl",
+        "output": "/chsend/32/6/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/6/on",
+        "output": "/chsend/32/6/mix_on"
+    },
+    {
+        "input": "/ch/32/send/7/lvl",
+        "output": "/chsend/32/7/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/7/on",
+        "output": "/chsend/32/7/mix_on"
+    },
+    {
+        "input": "/ch/32/send/8/lvl",
+        "output": "/chsend/32/8/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/8/on",
+        "output": "/chsend/32/8/mix_on"
+    },
+    {
+        "input": "/ch/32/send/9/lvl",
+        "output": "/chsend/32/9/mix_fader"
+    },
+    {
+        "input": "/ch/32/send/9/on",
+        "output": "/chsend/32/9/mix_on"
+    },
+    {
+        "input": "/ch/33/col",
+        "output": "/ch/33/config_color"
+    },
+    {
+        "input": "/ch/33/fdr",
+        "output": "/ch/33/mix_fader"
+    },
+    {
+        "input": "/ch/33/in/conn/altgrp",
+        "output": "/ch/33/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/33/in/conn/altin",
+        "output": "/ch/33/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/33/in/conn/grp",
+        "output": "/ch/33/input_conn_grp"
+    },
+    {
+        "input": "/ch/33/in/conn/in",
+        "output": "/ch/33/input_conn_in"
+    },
+    {
+        "input": "/ch/33/in/set/$g",
+        "output": "/ch/33/preamp_gain"
+    },
+    {
+        "input": "/ch/33/in/set/$mode",
+        "output": "/ch/33/input_mode"
+    },
+    {
+        "input": "/ch/33/in/set/$vph",
+        "output": "/ch/33/preamp_phantom"
+    },
+    {
+        "input": "/ch/33/in/set/altsrc",
+        "output": "/ch/33/input_altsrc"
+    },
+    {
+        "input": "/ch/33/in/set/bal",
+        "output": "/ch/33/input_balance"
+    },
+    {
+        "input": "/ch/33/in/set/dly",
+        "output": "/ch/33/input_delay"
+    },
+    {
+        "input": "/ch/33/in/set/dlymode",
+        "output": "/ch/33/input_delay_mode"
+    },
+    {
+        "input": "/ch/33/in/set/dlyon",
+        "output": "/ch/33/input_delay_on"
+    },
+    {
+        "input": "/ch/33/in/set/inv",
+        "output": "/ch/33/input_invert"
+    },
+    {
+        "input": "/ch/33/in/set/srcauto",
+        "output": "/ch/33/input_srcauto"
+    },
+    {
+        "input": "/ch/33/in/set/trim",
+        "output": "/ch/33/input_trim"
+    },
+    {
+        "input": "/ch/33/mute",
+        "output": "/ch/33/mix_on"
+    },
+    {
+        "input": "/ch/33/name",
+        "output": "/ch/33/config_name"
+    },
+    {
+        "input": "/ch/33/send/1/lvl",
+        "output": "/chsend/33/1/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/1/on",
+        "output": "/chsend/33/1/mix_on"
+    },
+    {
+        "input": "/ch/33/send/10/lvl",
+        "output": "/chsend/33/10/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/10/on",
+        "output": "/chsend/33/10/mix_on"
+    },
+    {
+        "input": "/ch/33/send/11/lvl",
+        "output": "/chsend/33/11/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/11/on",
+        "output": "/chsend/33/11/mix_on"
+    },
+    {
+        "input": "/ch/33/send/12/lvl",
+        "output": "/chsend/33/12/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/12/on",
+        "output": "/chsend/33/12/mix_on"
+    },
+    {
+        "input": "/ch/33/send/13/lvl",
+        "output": "/chsend/33/13/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/13/on",
+        "output": "/chsend/33/13/mix_on"
+    },
+    {
+        "input": "/ch/33/send/14/lvl",
+        "output": "/chsend/33/14/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/14/on",
+        "output": "/chsend/33/14/mix_on"
+    },
+    {
+        "input": "/ch/33/send/15/lvl",
+        "output": "/chsend/33/15/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/15/on",
+        "output": "/chsend/33/15/mix_on"
+    },
+    {
+        "input": "/ch/33/send/16/lvl",
+        "output": "/chsend/33/16/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/16/on",
+        "output": "/chsend/33/16/mix_on"
+    },
+    {
+        "input": "/ch/33/send/2/lvl",
+        "output": "/chsend/33/2/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/2/on",
+        "output": "/chsend/33/2/mix_on"
+    },
+    {
+        "input": "/ch/33/send/3/lvl",
+        "output": "/chsend/33/3/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/3/on",
+        "output": "/chsend/33/3/mix_on"
+    },
+    {
+        "input": "/ch/33/send/4/lvl",
+        "output": "/chsend/33/4/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/4/on",
+        "output": "/chsend/33/4/mix_on"
+    },
+    {
+        "input": "/ch/33/send/5/lvl",
+        "output": "/chsend/33/5/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/5/on",
+        "output": "/chsend/33/5/mix_on"
+    },
+    {
+        "input": "/ch/33/send/6/lvl",
+        "output": "/chsend/33/6/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/6/on",
+        "output": "/chsend/33/6/mix_on"
+    },
+    {
+        "input": "/ch/33/send/7/lvl",
+        "output": "/chsend/33/7/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/7/on",
+        "output": "/chsend/33/7/mix_on"
+    },
+    {
+        "input": "/ch/33/send/8/lvl",
+        "output": "/chsend/33/8/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/8/on",
+        "output": "/chsend/33/8/mix_on"
+    },
+    {
+        "input": "/ch/33/send/9/lvl",
+        "output": "/chsend/33/9/mix_fader"
+    },
+    {
+        "input": "/ch/33/send/9/on",
+        "output": "/chsend/33/9/mix_on"
+    },
+    {
+        "input": "/ch/34/col",
+        "output": "/ch/34/config_color"
+    },
+    {
+        "input": "/ch/34/fdr",
+        "output": "/ch/34/mix_fader"
+    },
+    {
+        "input": "/ch/34/in/conn/altgrp",
+        "output": "/ch/34/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/34/in/conn/altin",
+        "output": "/ch/34/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/34/in/conn/grp",
+        "output": "/ch/34/input_conn_grp"
+    },
+    {
+        "input": "/ch/34/in/conn/in",
+        "output": "/ch/34/input_conn_in"
+    },
+    {
+        "input": "/ch/34/in/set/$g",
+        "output": "/ch/34/preamp_gain"
+    },
+    {
+        "input": "/ch/34/in/set/$mode",
+        "output": "/ch/34/input_mode"
+    },
+    {
+        "input": "/ch/34/in/set/$vph",
+        "output": "/ch/34/preamp_phantom"
+    },
+    {
+        "input": "/ch/34/in/set/altsrc",
+        "output": "/ch/34/input_altsrc"
+    },
+    {
+        "input": "/ch/34/in/set/bal",
+        "output": "/ch/34/input_balance"
+    },
+    {
+        "input": "/ch/34/in/set/dly",
+        "output": "/ch/34/input_delay"
+    },
+    {
+        "input": "/ch/34/in/set/dlymode",
+        "output": "/ch/34/input_delay_mode"
+    },
+    {
+        "input": "/ch/34/in/set/dlyon",
+        "output": "/ch/34/input_delay_on"
+    },
+    {
+        "input": "/ch/34/in/set/inv",
+        "output": "/ch/34/input_invert"
+    },
+    {
+        "input": "/ch/34/in/set/srcauto",
+        "output": "/ch/34/input_srcauto"
+    },
+    {
+        "input": "/ch/34/in/set/trim",
+        "output": "/ch/34/input_trim"
+    },
+    {
+        "input": "/ch/34/mute",
+        "output": "/ch/34/mix_on"
+    },
+    {
+        "input": "/ch/34/name",
+        "output": "/ch/34/config_name"
+    },
+    {
+        "input": "/ch/34/send/1/lvl",
+        "output": "/chsend/34/1/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/1/on",
+        "output": "/chsend/34/1/mix_on"
+    },
+    {
+        "input": "/ch/34/send/10/lvl",
+        "output": "/chsend/34/10/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/10/on",
+        "output": "/chsend/34/10/mix_on"
+    },
+    {
+        "input": "/ch/34/send/11/lvl",
+        "output": "/chsend/34/11/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/11/on",
+        "output": "/chsend/34/11/mix_on"
+    },
+    {
+        "input": "/ch/34/send/12/lvl",
+        "output": "/chsend/34/12/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/12/on",
+        "output": "/chsend/34/12/mix_on"
+    },
+    {
+        "input": "/ch/34/send/13/lvl",
+        "output": "/chsend/34/13/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/13/on",
+        "output": "/chsend/34/13/mix_on"
+    },
+    {
+        "input": "/ch/34/send/14/lvl",
+        "output": "/chsend/34/14/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/14/on",
+        "output": "/chsend/34/14/mix_on"
+    },
+    {
+        "input": "/ch/34/send/15/lvl",
+        "output": "/chsend/34/15/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/15/on",
+        "output": "/chsend/34/15/mix_on"
+    },
+    {
+        "input": "/ch/34/send/16/lvl",
+        "output": "/chsend/34/16/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/16/on",
+        "output": "/chsend/34/16/mix_on"
+    },
+    {
+        "input": "/ch/34/send/2/lvl",
+        "output": "/chsend/34/2/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/2/on",
+        "output": "/chsend/34/2/mix_on"
+    },
+    {
+        "input": "/ch/34/send/3/lvl",
+        "output": "/chsend/34/3/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/3/on",
+        "output": "/chsend/34/3/mix_on"
+    },
+    {
+        "input": "/ch/34/send/4/lvl",
+        "output": "/chsend/34/4/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/4/on",
+        "output": "/chsend/34/4/mix_on"
+    },
+    {
+        "input": "/ch/34/send/5/lvl",
+        "output": "/chsend/34/5/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/5/on",
+        "output": "/chsend/34/5/mix_on"
+    },
+    {
+        "input": "/ch/34/send/6/lvl",
+        "output": "/chsend/34/6/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/6/on",
+        "output": "/chsend/34/6/mix_on"
+    },
+    {
+        "input": "/ch/34/send/7/lvl",
+        "output": "/chsend/34/7/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/7/on",
+        "output": "/chsend/34/7/mix_on"
+    },
+    {
+        "input": "/ch/34/send/8/lvl",
+        "output": "/chsend/34/8/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/8/on",
+        "output": "/chsend/34/8/mix_on"
+    },
+    {
+        "input": "/ch/34/send/9/lvl",
+        "output": "/chsend/34/9/mix_fader"
+    },
+    {
+        "input": "/ch/34/send/9/on",
+        "output": "/chsend/34/9/mix_on"
+    },
+    {
+        "input": "/ch/35/col",
+        "output": "/ch/35/config_color"
+    },
+    {
+        "input": "/ch/35/fdr",
+        "output": "/ch/35/mix_fader"
+    },
+    {
+        "input": "/ch/35/in/conn/altgrp",
+        "output": "/ch/35/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/35/in/conn/altin",
+        "output": "/ch/35/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/35/in/conn/grp",
+        "output": "/ch/35/input_conn_grp"
+    },
+    {
+        "input": "/ch/35/in/conn/in",
+        "output": "/ch/35/input_conn_in"
+    },
+    {
+        "input": "/ch/35/in/set/$g",
+        "output": "/ch/35/preamp_gain"
+    },
+    {
+        "input": "/ch/35/in/set/$mode",
+        "output": "/ch/35/input_mode"
+    },
+    {
+        "input": "/ch/35/in/set/$vph",
+        "output": "/ch/35/preamp_phantom"
+    },
+    {
+        "input": "/ch/35/in/set/altsrc",
+        "output": "/ch/35/input_altsrc"
+    },
+    {
+        "input": "/ch/35/in/set/bal",
+        "output": "/ch/35/input_balance"
+    },
+    {
+        "input": "/ch/35/in/set/dly",
+        "output": "/ch/35/input_delay"
+    },
+    {
+        "input": "/ch/35/in/set/dlymode",
+        "output": "/ch/35/input_delay_mode"
+    },
+    {
+        "input": "/ch/35/in/set/dlyon",
+        "output": "/ch/35/input_delay_on"
+    },
+    {
+        "input": "/ch/35/in/set/inv",
+        "output": "/ch/35/input_invert"
+    },
+    {
+        "input": "/ch/35/in/set/srcauto",
+        "output": "/ch/35/input_srcauto"
+    },
+    {
+        "input": "/ch/35/in/set/trim",
+        "output": "/ch/35/input_trim"
+    },
+    {
+        "input": "/ch/35/mute",
+        "output": "/ch/35/mix_on"
+    },
+    {
+        "input": "/ch/35/name",
+        "output": "/ch/35/config_name"
+    },
+    {
+        "input": "/ch/35/send/1/lvl",
+        "output": "/chsend/35/1/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/1/on",
+        "output": "/chsend/35/1/mix_on"
+    },
+    {
+        "input": "/ch/35/send/10/lvl",
+        "output": "/chsend/35/10/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/10/on",
+        "output": "/chsend/35/10/mix_on"
+    },
+    {
+        "input": "/ch/35/send/11/lvl",
+        "output": "/chsend/35/11/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/11/on",
+        "output": "/chsend/35/11/mix_on"
+    },
+    {
+        "input": "/ch/35/send/12/lvl",
+        "output": "/chsend/35/12/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/12/on",
+        "output": "/chsend/35/12/mix_on"
+    },
+    {
+        "input": "/ch/35/send/13/lvl",
+        "output": "/chsend/35/13/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/13/on",
+        "output": "/chsend/35/13/mix_on"
+    },
+    {
+        "input": "/ch/35/send/14/lvl",
+        "output": "/chsend/35/14/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/14/on",
+        "output": "/chsend/35/14/mix_on"
+    },
+    {
+        "input": "/ch/35/send/15/lvl",
+        "output": "/chsend/35/15/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/15/on",
+        "output": "/chsend/35/15/mix_on"
+    },
+    {
+        "input": "/ch/35/send/16/lvl",
+        "output": "/chsend/35/16/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/16/on",
+        "output": "/chsend/35/16/mix_on"
+    },
+    {
+        "input": "/ch/35/send/2/lvl",
+        "output": "/chsend/35/2/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/2/on",
+        "output": "/chsend/35/2/mix_on"
+    },
+    {
+        "input": "/ch/35/send/3/lvl",
+        "output": "/chsend/35/3/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/3/on",
+        "output": "/chsend/35/3/mix_on"
+    },
+    {
+        "input": "/ch/35/send/4/lvl",
+        "output": "/chsend/35/4/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/4/on",
+        "output": "/chsend/35/4/mix_on"
+    },
+    {
+        "input": "/ch/35/send/5/lvl",
+        "output": "/chsend/35/5/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/5/on",
+        "output": "/chsend/35/5/mix_on"
+    },
+    {
+        "input": "/ch/35/send/6/lvl",
+        "output": "/chsend/35/6/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/6/on",
+        "output": "/chsend/35/6/mix_on"
+    },
+    {
+        "input": "/ch/35/send/7/lvl",
+        "output": "/chsend/35/7/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/7/on",
+        "output": "/chsend/35/7/mix_on"
+    },
+    {
+        "input": "/ch/35/send/8/lvl",
+        "output": "/chsend/35/8/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/8/on",
+        "output": "/chsend/35/8/mix_on"
+    },
+    {
+        "input": "/ch/35/send/9/lvl",
+        "output": "/chsend/35/9/mix_fader"
+    },
+    {
+        "input": "/ch/35/send/9/on",
+        "output": "/chsend/35/9/mix_on"
+    },
+    {
+        "input": "/ch/36/col",
+        "output": "/ch/36/config_color"
+    },
+    {
+        "input": "/ch/36/fdr",
+        "output": "/ch/36/mix_fader"
+    },
+    {
+        "input": "/ch/36/in/conn/altgrp",
+        "output": "/ch/36/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/36/in/conn/altin",
+        "output": "/ch/36/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/36/in/conn/grp",
+        "output": "/ch/36/input_conn_grp"
+    },
+    {
+        "input": "/ch/36/in/conn/in",
+        "output": "/ch/36/input_conn_in"
+    },
+    {
+        "input": "/ch/36/in/set/$g",
+        "output": "/ch/36/preamp_gain"
+    },
+    {
+        "input": "/ch/36/in/set/$mode",
+        "output": "/ch/36/input_mode"
+    },
+    {
+        "input": "/ch/36/in/set/$vph",
+        "output": "/ch/36/preamp_phantom"
+    },
+    {
+        "input": "/ch/36/in/set/altsrc",
+        "output": "/ch/36/input_altsrc"
+    },
+    {
+        "input": "/ch/36/in/set/bal",
+        "output": "/ch/36/input_balance"
+    },
+    {
+        "input": "/ch/36/in/set/dly",
+        "output": "/ch/36/input_delay"
+    },
+    {
+        "input": "/ch/36/in/set/dlymode",
+        "output": "/ch/36/input_delay_mode"
+    },
+    {
+        "input": "/ch/36/in/set/dlyon",
+        "output": "/ch/36/input_delay_on"
+    },
+    {
+        "input": "/ch/36/in/set/inv",
+        "output": "/ch/36/input_invert"
+    },
+    {
+        "input": "/ch/36/in/set/srcauto",
+        "output": "/ch/36/input_srcauto"
+    },
+    {
+        "input": "/ch/36/in/set/trim",
+        "output": "/ch/36/input_trim"
+    },
+    {
+        "input": "/ch/36/mute",
+        "output": "/ch/36/mix_on"
+    },
+    {
+        "input": "/ch/36/name",
+        "output": "/ch/36/config_name"
+    },
+    {
+        "input": "/ch/36/send/1/lvl",
+        "output": "/chsend/36/1/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/1/on",
+        "output": "/chsend/36/1/mix_on"
+    },
+    {
+        "input": "/ch/36/send/10/lvl",
+        "output": "/chsend/36/10/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/10/on",
+        "output": "/chsend/36/10/mix_on"
+    },
+    {
+        "input": "/ch/36/send/11/lvl",
+        "output": "/chsend/36/11/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/11/on",
+        "output": "/chsend/36/11/mix_on"
+    },
+    {
+        "input": "/ch/36/send/12/lvl",
+        "output": "/chsend/36/12/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/12/on",
+        "output": "/chsend/36/12/mix_on"
+    },
+    {
+        "input": "/ch/36/send/13/lvl",
+        "output": "/chsend/36/13/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/13/on",
+        "output": "/chsend/36/13/mix_on"
+    },
+    {
+        "input": "/ch/36/send/14/lvl",
+        "output": "/chsend/36/14/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/14/on",
+        "output": "/chsend/36/14/mix_on"
+    },
+    {
+        "input": "/ch/36/send/15/lvl",
+        "output": "/chsend/36/15/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/15/on",
+        "output": "/chsend/36/15/mix_on"
+    },
+    {
+        "input": "/ch/36/send/16/lvl",
+        "output": "/chsend/36/16/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/16/on",
+        "output": "/chsend/36/16/mix_on"
+    },
+    {
+        "input": "/ch/36/send/2/lvl",
+        "output": "/chsend/36/2/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/2/on",
+        "output": "/chsend/36/2/mix_on"
+    },
+    {
+        "input": "/ch/36/send/3/lvl",
+        "output": "/chsend/36/3/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/3/on",
+        "output": "/chsend/36/3/mix_on"
+    },
+    {
+        "input": "/ch/36/send/4/lvl",
+        "output": "/chsend/36/4/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/4/on",
+        "output": "/chsend/36/4/mix_on"
+    },
+    {
+        "input": "/ch/36/send/5/lvl",
+        "output": "/chsend/36/5/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/5/on",
+        "output": "/chsend/36/5/mix_on"
+    },
+    {
+        "input": "/ch/36/send/6/lvl",
+        "output": "/chsend/36/6/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/6/on",
+        "output": "/chsend/36/6/mix_on"
+    },
+    {
+        "input": "/ch/36/send/7/lvl",
+        "output": "/chsend/36/7/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/7/on",
+        "output": "/chsend/36/7/mix_on"
+    },
+    {
+        "input": "/ch/36/send/8/lvl",
+        "output": "/chsend/36/8/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/8/on",
+        "output": "/chsend/36/8/mix_on"
+    },
+    {
+        "input": "/ch/36/send/9/lvl",
+        "output": "/chsend/36/9/mix_fader"
+    },
+    {
+        "input": "/ch/36/send/9/on",
+        "output": "/chsend/36/9/mix_on"
+    },
+    {
+        "input": "/ch/37/col",
+        "output": "/ch/37/config_color"
+    },
+    {
+        "input": "/ch/37/fdr",
+        "output": "/ch/37/mix_fader"
+    },
+    {
+        "input": "/ch/37/in/conn/altgrp",
+        "output": "/ch/37/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/37/in/conn/altin",
+        "output": "/ch/37/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/37/in/conn/grp",
+        "output": "/ch/37/input_conn_grp"
+    },
+    {
+        "input": "/ch/37/in/conn/in",
+        "output": "/ch/37/input_conn_in"
+    },
+    {
+        "input": "/ch/37/in/set/$g",
+        "output": "/ch/37/preamp_gain"
+    },
+    {
+        "input": "/ch/37/in/set/$mode",
+        "output": "/ch/37/input_mode"
+    },
+    {
+        "input": "/ch/37/in/set/$vph",
+        "output": "/ch/37/preamp_phantom"
+    },
+    {
+        "input": "/ch/37/in/set/altsrc",
+        "output": "/ch/37/input_altsrc"
+    },
+    {
+        "input": "/ch/37/in/set/bal",
+        "output": "/ch/37/input_balance"
+    },
+    {
+        "input": "/ch/37/in/set/dly",
+        "output": "/ch/37/input_delay"
+    },
+    {
+        "input": "/ch/37/in/set/dlymode",
+        "output": "/ch/37/input_delay_mode"
+    },
+    {
+        "input": "/ch/37/in/set/dlyon",
+        "output": "/ch/37/input_delay_on"
+    },
+    {
+        "input": "/ch/37/in/set/inv",
+        "output": "/ch/37/input_invert"
+    },
+    {
+        "input": "/ch/37/in/set/srcauto",
+        "output": "/ch/37/input_srcauto"
+    },
+    {
+        "input": "/ch/37/in/set/trim",
+        "output": "/ch/37/input_trim"
+    },
+    {
+        "input": "/ch/37/mute",
+        "output": "/ch/37/mix_on"
+    },
+    {
+        "input": "/ch/37/name",
+        "output": "/ch/37/config_name"
+    },
+    {
+        "input": "/ch/37/send/1/lvl",
+        "output": "/chsend/37/1/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/1/on",
+        "output": "/chsend/37/1/mix_on"
+    },
+    {
+        "input": "/ch/37/send/10/lvl",
+        "output": "/chsend/37/10/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/10/on",
+        "output": "/chsend/37/10/mix_on"
+    },
+    {
+        "input": "/ch/37/send/11/lvl",
+        "output": "/chsend/37/11/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/11/on",
+        "output": "/chsend/37/11/mix_on"
+    },
+    {
+        "input": "/ch/37/send/12/lvl",
+        "output": "/chsend/37/12/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/12/on",
+        "output": "/chsend/37/12/mix_on"
+    },
+    {
+        "input": "/ch/37/send/13/lvl",
+        "output": "/chsend/37/13/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/13/on",
+        "output": "/chsend/37/13/mix_on"
+    },
+    {
+        "input": "/ch/37/send/14/lvl",
+        "output": "/chsend/37/14/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/14/on",
+        "output": "/chsend/37/14/mix_on"
+    },
+    {
+        "input": "/ch/37/send/15/lvl",
+        "output": "/chsend/37/15/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/15/on",
+        "output": "/chsend/37/15/mix_on"
+    },
+    {
+        "input": "/ch/37/send/16/lvl",
+        "output": "/chsend/37/16/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/16/on",
+        "output": "/chsend/37/16/mix_on"
+    },
+    {
+        "input": "/ch/37/send/2/lvl",
+        "output": "/chsend/37/2/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/2/on",
+        "output": "/chsend/37/2/mix_on"
+    },
+    {
+        "input": "/ch/37/send/3/lvl",
+        "output": "/chsend/37/3/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/3/on",
+        "output": "/chsend/37/3/mix_on"
+    },
+    {
+        "input": "/ch/37/send/4/lvl",
+        "output": "/chsend/37/4/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/4/on",
+        "output": "/chsend/37/4/mix_on"
+    },
+    {
+        "input": "/ch/37/send/5/lvl",
+        "output": "/chsend/37/5/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/5/on",
+        "output": "/chsend/37/5/mix_on"
+    },
+    {
+        "input": "/ch/37/send/6/lvl",
+        "output": "/chsend/37/6/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/6/on",
+        "output": "/chsend/37/6/mix_on"
+    },
+    {
+        "input": "/ch/37/send/7/lvl",
+        "output": "/chsend/37/7/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/7/on",
+        "output": "/chsend/37/7/mix_on"
+    },
+    {
+        "input": "/ch/37/send/8/lvl",
+        "output": "/chsend/37/8/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/8/on",
+        "output": "/chsend/37/8/mix_on"
+    },
+    {
+        "input": "/ch/37/send/9/lvl",
+        "output": "/chsend/37/9/mix_fader"
+    },
+    {
+        "input": "/ch/37/send/9/on",
+        "output": "/chsend/37/9/mix_on"
+    },
+    {
+        "input": "/ch/38/col",
+        "output": "/ch/38/config_color"
+    },
+    {
+        "input": "/ch/38/fdr",
+        "output": "/ch/38/mix_fader"
+    },
+    {
+        "input": "/ch/38/in/conn/altgrp",
+        "output": "/ch/38/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/38/in/conn/altin",
+        "output": "/ch/38/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/38/in/conn/grp",
+        "output": "/ch/38/input_conn_grp"
+    },
+    {
+        "input": "/ch/38/in/conn/in",
+        "output": "/ch/38/input_conn_in"
+    },
+    {
+        "input": "/ch/38/in/set/$g",
+        "output": "/ch/38/preamp_gain"
+    },
+    {
+        "input": "/ch/38/in/set/$mode",
+        "output": "/ch/38/input_mode"
+    },
+    {
+        "input": "/ch/38/in/set/$vph",
+        "output": "/ch/38/preamp_phantom"
+    },
+    {
+        "input": "/ch/38/in/set/altsrc",
+        "output": "/ch/38/input_altsrc"
+    },
+    {
+        "input": "/ch/38/in/set/bal",
+        "output": "/ch/38/input_balance"
+    },
+    {
+        "input": "/ch/38/in/set/dly",
+        "output": "/ch/38/input_delay"
+    },
+    {
+        "input": "/ch/38/in/set/dlymode",
+        "output": "/ch/38/input_delay_mode"
+    },
+    {
+        "input": "/ch/38/in/set/dlyon",
+        "output": "/ch/38/input_delay_on"
+    },
+    {
+        "input": "/ch/38/in/set/inv",
+        "output": "/ch/38/input_invert"
+    },
+    {
+        "input": "/ch/38/in/set/srcauto",
+        "output": "/ch/38/input_srcauto"
+    },
+    {
+        "input": "/ch/38/in/set/trim",
+        "output": "/ch/38/input_trim"
+    },
+    {
+        "input": "/ch/38/mute",
+        "output": "/ch/38/mix_on"
+    },
+    {
+        "input": "/ch/38/name",
+        "output": "/ch/38/config_name"
+    },
+    {
+        "input": "/ch/38/send/1/lvl",
+        "output": "/chsend/38/1/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/1/on",
+        "output": "/chsend/38/1/mix_on"
+    },
+    {
+        "input": "/ch/38/send/10/lvl",
+        "output": "/chsend/38/10/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/10/on",
+        "output": "/chsend/38/10/mix_on"
+    },
+    {
+        "input": "/ch/38/send/11/lvl",
+        "output": "/chsend/38/11/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/11/on",
+        "output": "/chsend/38/11/mix_on"
+    },
+    {
+        "input": "/ch/38/send/12/lvl",
+        "output": "/chsend/38/12/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/12/on",
+        "output": "/chsend/38/12/mix_on"
+    },
+    {
+        "input": "/ch/38/send/13/lvl",
+        "output": "/chsend/38/13/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/13/on",
+        "output": "/chsend/38/13/mix_on"
+    },
+    {
+        "input": "/ch/38/send/14/lvl",
+        "output": "/chsend/38/14/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/14/on",
+        "output": "/chsend/38/14/mix_on"
+    },
+    {
+        "input": "/ch/38/send/15/lvl",
+        "output": "/chsend/38/15/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/15/on",
+        "output": "/chsend/38/15/mix_on"
+    },
+    {
+        "input": "/ch/38/send/16/lvl",
+        "output": "/chsend/38/16/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/16/on",
+        "output": "/chsend/38/16/mix_on"
+    },
+    {
+        "input": "/ch/38/send/2/lvl",
+        "output": "/chsend/38/2/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/2/on",
+        "output": "/chsend/38/2/mix_on"
+    },
+    {
+        "input": "/ch/38/send/3/lvl",
+        "output": "/chsend/38/3/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/3/on",
+        "output": "/chsend/38/3/mix_on"
+    },
+    {
+        "input": "/ch/38/send/4/lvl",
+        "output": "/chsend/38/4/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/4/on",
+        "output": "/chsend/38/4/mix_on"
+    },
+    {
+        "input": "/ch/38/send/5/lvl",
+        "output": "/chsend/38/5/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/5/on",
+        "output": "/chsend/38/5/mix_on"
+    },
+    {
+        "input": "/ch/38/send/6/lvl",
+        "output": "/chsend/38/6/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/6/on",
+        "output": "/chsend/38/6/mix_on"
+    },
+    {
+        "input": "/ch/38/send/7/lvl",
+        "output": "/chsend/38/7/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/7/on",
+        "output": "/chsend/38/7/mix_on"
+    },
+    {
+        "input": "/ch/38/send/8/lvl",
+        "output": "/chsend/38/8/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/8/on",
+        "output": "/chsend/38/8/mix_on"
+    },
+    {
+        "input": "/ch/38/send/9/lvl",
+        "output": "/chsend/38/9/mix_fader"
+    },
+    {
+        "input": "/ch/38/send/9/on",
+        "output": "/chsend/38/9/mix_on"
+    },
+    {
+        "input": "/ch/39/col",
+        "output": "/ch/39/config_color"
+    },
+    {
+        "input": "/ch/39/fdr",
+        "output": "/ch/39/mix_fader"
+    },
+    {
+        "input": "/ch/39/in/conn/altgrp",
+        "output": "/ch/39/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/39/in/conn/altin",
+        "output": "/ch/39/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/39/in/conn/grp",
+        "output": "/ch/39/input_conn_grp"
+    },
+    {
+        "input": "/ch/39/in/conn/in",
+        "output": "/ch/39/input_conn_in"
+    },
+    {
+        "input": "/ch/39/in/set/$g",
+        "output": "/ch/39/preamp_gain"
+    },
+    {
+        "input": "/ch/39/in/set/$mode",
+        "output": "/ch/39/input_mode"
+    },
+    {
+        "input": "/ch/39/in/set/$vph",
+        "output": "/ch/39/preamp_phantom"
+    },
+    {
+        "input": "/ch/39/in/set/altsrc",
+        "output": "/ch/39/input_altsrc"
+    },
+    {
+        "input": "/ch/39/in/set/bal",
+        "output": "/ch/39/input_balance"
+    },
+    {
+        "input": "/ch/39/in/set/dly",
+        "output": "/ch/39/input_delay"
+    },
+    {
+        "input": "/ch/39/in/set/dlymode",
+        "output": "/ch/39/input_delay_mode"
+    },
+    {
+        "input": "/ch/39/in/set/dlyon",
+        "output": "/ch/39/input_delay_on"
+    },
+    {
+        "input": "/ch/39/in/set/inv",
+        "output": "/ch/39/input_invert"
+    },
+    {
+        "input": "/ch/39/in/set/srcauto",
+        "output": "/ch/39/input_srcauto"
+    },
+    {
+        "input": "/ch/39/in/set/trim",
+        "output": "/ch/39/input_trim"
+    },
+    {
+        "input": "/ch/39/mute",
+        "output": "/ch/39/mix_on"
+    },
+    {
+        "input": "/ch/39/name",
+        "output": "/ch/39/config_name"
+    },
+    {
+        "input": "/ch/39/send/1/lvl",
+        "output": "/chsend/39/1/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/1/on",
+        "output": "/chsend/39/1/mix_on"
+    },
+    {
+        "input": "/ch/39/send/10/lvl",
+        "output": "/chsend/39/10/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/10/on",
+        "output": "/chsend/39/10/mix_on"
+    },
+    {
+        "input": "/ch/39/send/11/lvl",
+        "output": "/chsend/39/11/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/11/on",
+        "output": "/chsend/39/11/mix_on"
+    },
+    {
+        "input": "/ch/39/send/12/lvl",
+        "output": "/chsend/39/12/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/12/on",
+        "output": "/chsend/39/12/mix_on"
+    },
+    {
+        "input": "/ch/39/send/13/lvl",
+        "output": "/chsend/39/13/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/13/on",
+        "output": "/chsend/39/13/mix_on"
+    },
+    {
+        "input": "/ch/39/send/14/lvl",
+        "output": "/chsend/39/14/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/14/on",
+        "output": "/chsend/39/14/mix_on"
+    },
+    {
+        "input": "/ch/39/send/15/lvl",
+        "output": "/chsend/39/15/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/15/on",
+        "output": "/chsend/39/15/mix_on"
+    },
+    {
+        "input": "/ch/39/send/16/lvl",
+        "output": "/chsend/39/16/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/16/on",
+        "output": "/chsend/39/16/mix_on"
+    },
+    {
+        "input": "/ch/39/send/2/lvl",
+        "output": "/chsend/39/2/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/2/on",
+        "output": "/chsend/39/2/mix_on"
+    },
+    {
+        "input": "/ch/39/send/3/lvl",
+        "output": "/chsend/39/3/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/3/on",
+        "output": "/chsend/39/3/mix_on"
+    },
+    {
+        "input": "/ch/39/send/4/lvl",
+        "output": "/chsend/39/4/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/4/on",
+        "output": "/chsend/39/4/mix_on"
+    },
+    {
+        "input": "/ch/39/send/5/lvl",
+        "output": "/chsend/39/5/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/5/on",
+        "output": "/chsend/39/5/mix_on"
+    },
+    {
+        "input": "/ch/39/send/6/lvl",
+        "output": "/chsend/39/6/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/6/on",
+        "output": "/chsend/39/6/mix_on"
+    },
+    {
+        "input": "/ch/39/send/7/lvl",
+        "output": "/chsend/39/7/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/7/on",
+        "output": "/chsend/39/7/mix_on"
+    },
+    {
+        "input": "/ch/39/send/8/lvl",
+        "output": "/chsend/39/8/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/8/on",
+        "output": "/chsend/39/8/mix_on"
+    },
+    {
+        "input": "/ch/39/send/9/lvl",
+        "output": "/chsend/39/9/mix_fader"
+    },
+    {
+        "input": "/ch/39/send/9/on",
+        "output": "/chsend/39/9/mix_on"
+    },
+    {
+        "input": "/ch/4/col",
+        "output": "/ch/4/config_color"
+    },
+    {
+        "input": "/ch/4/fdr",
+        "output": "/ch/4/mix_fader"
+    },
+    {
+        "input": "/ch/4/in/conn/altgrp",
+        "output": "/ch/4/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/4/in/conn/altin",
+        "output": "/ch/4/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/4/in/conn/grp",
+        "output": "/ch/4/input_conn_grp"
+    },
+    {
+        "input": "/ch/4/in/conn/in",
+        "output": "/ch/4/input_conn_in"
+    },
+    {
+        "input": "/ch/4/in/set/$g",
+        "output": "/ch/4/preamp_gain"
+    },
+    {
+        "input": "/ch/4/in/set/$mode",
+        "output": "/ch/4/input_mode"
+    },
+    {
+        "input": "/ch/4/in/set/$vph",
+        "output": "/ch/4/preamp_phantom"
+    },
+    {
+        "input": "/ch/4/in/set/altsrc",
+        "output": "/ch/4/input_altsrc"
+    },
+    {
+        "input": "/ch/4/in/set/bal",
+        "output": "/ch/4/input_balance"
+    },
+    {
+        "input": "/ch/4/in/set/dly",
+        "output": "/ch/4/input_delay"
+    },
+    {
+        "input": "/ch/4/in/set/dlymode",
+        "output": "/ch/4/input_delay_mode"
+    },
+    {
+        "input": "/ch/4/in/set/dlyon",
+        "output": "/ch/4/input_delay_on"
+    },
+    {
+        "input": "/ch/4/in/set/inv",
+        "output": "/ch/4/input_invert"
+    },
+    {
+        "input": "/ch/4/in/set/srcauto",
+        "output": "/ch/4/input_srcauto"
+    },
+    {
+        "input": "/ch/4/in/set/trim",
+        "output": "/ch/4/input_trim"
+    },
+    {
+        "input": "/ch/4/mute",
+        "output": "/ch/4/mix_on"
+    },
+    {
+        "input": "/ch/4/name",
+        "output": "/ch/4/config_name"
+    },
+    {
+        "input": "/ch/4/send/1/lvl",
+        "output": "/chsend/4/1/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/1/on",
+        "output": "/chsend/4/1/mix_on"
+    },
+    {
+        "input": "/ch/4/send/10/lvl",
+        "output": "/chsend/4/10/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/10/on",
+        "output": "/chsend/4/10/mix_on"
+    },
+    {
+        "input": "/ch/4/send/11/lvl",
+        "output": "/chsend/4/11/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/11/on",
+        "output": "/chsend/4/11/mix_on"
+    },
+    {
+        "input": "/ch/4/send/12/lvl",
+        "output": "/chsend/4/12/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/12/on",
+        "output": "/chsend/4/12/mix_on"
+    },
+    {
+        "input": "/ch/4/send/13/lvl",
+        "output": "/chsend/4/13/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/13/on",
+        "output": "/chsend/4/13/mix_on"
+    },
+    {
+        "input": "/ch/4/send/14/lvl",
+        "output": "/chsend/4/14/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/14/on",
+        "output": "/chsend/4/14/mix_on"
+    },
+    {
+        "input": "/ch/4/send/15/lvl",
+        "output": "/chsend/4/15/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/15/on",
+        "output": "/chsend/4/15/mix_on"
+    },
+    {
+        "input": "/ch/4/send/16/lvl",
+        "output": "/chsend/4/16/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/16/on",
+        "output": "/chsend/4/16/mix_on"
+    },
+    {
+        "input": "/ch/4/send/2/lvl",
+        "output": "/chsend/4/2/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/2/on",
+        "output": "/chsend/4/2/mix_on"
+    },
+    {
+        "input": "/ch/4/send/3/lvl",
+        "output": "/chsend/4/3/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/3/on",
+        "output": "/chsend/4/3/mix_on"
+    },
+    {
+        "input": "/ch/4/send/4/lvl",
+        "output": "/chsend/4/4/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/4/on",
+        "output": "/chsend/4/4/mix_on"
+    },
+    {
+        "input": "/ch/4/send/5/lvl",
+        "output": "/chsend/4/5/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/5/on",
+        "output": "/chsend/4/5/mix_on"
+    },
+    {
+        "input": "/ch/4/send/6/lvl",
+        "output": "/chsend/4/6/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/6/on",
+        "output": "/chsend/4/6/mix_on"
+    },
+    {
+        "input": "/ch/4/send/7/lvl",
+        "output": "/chsend/4/7/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/7/on",
+        "output": "/chsend/4/7/mix_on"
+    },
+    {
+        "input": "/ch/4/send/8/lvl",
+        "output": "/chsend/4/8/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/8/on",
+        "output": "/chsend/4/8/mix_on"
+    },
+    {
+        "input": "/ch/4/send/9/lvl",
+        "output": "/chsend/4/9/mix_fader"
+    },
+    {
+        "input": "/ch/4/send/9/on",
+        "output": "/chsend/4/9/mix_on"
+    },
+    {
+        "input": "/ch/40/col",
+        "output": "/ch/40/config_color"
+    },
+    {
+        "input": "/ch/40/fdr",
+        "output": "/ch/40/mix_fader"
+    },
+    {
+        "input": "/ch/40/in/conn/altgrp",
+        "output": "/ch/40/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/40/in/conn/altin",
+        "output": "/ch/40/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/40/in/conn/grp",
+        "output": "/ch/40/input_conn_grp"
+    },
+    {
+        "input": "/ch/40/in/conn/in",
+        "output": "/ch/40/input_conn_in"
+    },
+    {
+        "input": "/ch/40/in/set/$g",
+        "output": "/ch/40/preamp_gain"
+    },
+    {
+        "input": "/ch/40/in/set/$mode",
+        "output": "/ch/40/input_mode"
+    },
+    {
+        "input": "/ch/40/in/set/$vph",
+        "output": "/ch/40/preamp_phantom"
+    },
+    {
+        "input": "/ch/40/in/set/altsrc",
+        "output": "/ch/40/input_altsrc"
+    },
+    {
+        "input": "/ch/40/in/set/bal",
+        "output": "/ch/40/input_balance"
+    },
+    {
+        "input": "/ch/40/in/set/dly",
+        "output": "/ch/40/input_delay"
+    },
+    {
+        "input": "/ch/40/in/set/dlymode",
+        "output": "/ch/40/input_delay_mode"
+    },
+    {
+        "input": "/ch/40/in/set/dlyon",
+        "output": "/ch/40/input_delay_on"
+    },
+    {
+        "input": "/ch/40/in/set/inv",
+        "output": "/ch/40/input_invert"
+    },
+    {
+        "input": "/ch/40/in/set/srcauto",
+        "output": "/ch/40/input_srcauto"
+    },
+    {
+        "input": "/ch/40/in/set/trim",
+        "output": "/ch/40/input_trim"
+    },
+    {
+        "input": "/ch/40/mute",
+        "output": "/ch/40/mix_on"
+    },
+    {
+        "input": "/ch/40/name",
+        "output": "/ch/40/config_name"
+    },
+    {
+        "input": "/ch/40/send/1/lvl",
+        "output": "/chsend/40/1/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/1/on",
+        "output": "/chsend/40/1/mix_on"
+    },
+    {
+        "input": "/ch/40/send/10/lvl",
+        "output": "/chsend/40/10/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/10/on",
+        "output": "/chsend/40/10/mix_on"
+    },
+    {
+        "input": "/ch/40/send/11/lvl",
+        "output": "/chsend/40/11/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/11/on",
+        "output": "/chsend/40/11/mix_on"
+    },
+    {
+        "input": "/ch/40/send/12/lvl",
+        "output": "/chsend/40/12/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/12/on",
+        "output": "/chsend/40/12/mix_on"
+    },
+    {
+        "input": "/ch/40/send/13/lvl",
+        "output": "/chsend/40/13/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/13/on",
+        "output": "/chsend/40/13/mix_on"
+    },
+    {
+        "input": "/ch/40/send/14/lvl",
+        "output": "/chsend/40/14/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/14/on",
+        "output": "/chsend/40/14/mix_on"
+    },
+    {
+        "input": "/ch/40/send/15/lvl",
+        "output": "/chsend/40/15/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/15/on",
+        "output": "/chsend/40/15/mix_on"
+    },
+    {
+        "input": "/ch/40/send/16/lvl",
+        "output": "/chsend/40/16/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/16/on",
+        "output": "/chsend/40/16/mix_on"
+    },
+    {
+        "input": "/ch/40/send/2/lvl",
+        "output": "/chsend/40/2/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/2/on",
+        "output": "/chsend/40/2/mix_on"
+    },
+    {
+        "input": "/ch/40/send/3/lvl",
+        "output": "/chsend/40/3/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/3/on",
+        "output": "/chsend/40/3/mix_on"
+    },
+    {
+        "input": "/ch/40/send/4/lvl",
+        "output": "/chsend/40/4/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/4/on",
+        "output": "/chsend/40/4/mix_on"
+    },
+    {
+        "input": "/ch/40/send/5/lvl",
+        "output": "/chsend/40/5/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/5/on",
+        "output": "/chsend/40/5/mix_on"
+    },
+    {
+        "input": "/ch/40/send/6/lvl",
+        "output": "/chsend/40/6/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/6/on",
+        "output": "/chsend/40/6/mix_on"
+    },
+    {
+        "input": "/ch/40/send/7/lvl",
+        "output": "/chsend/40/7/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/7/on",
+        "output": "/chsend/40/7/mix_on"
+    },
+    {
+        "input": "/ch/40/send/8/lvl",
+        "output": "/chsend/40/8/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/8/on",
+        "output": "/chsend/40/8/mix_on"
+    },
+    {
+        "input": "/ch/40/send/9/lvl",
+        "output": "/chsend/40/9/mix_fader"
+    },
+    {
+        "input": "/ch/40/send/9/on",
+        "output": "/chsend/40/9/mix_on"
+    },
+    {
+        "input": "/ch/5/col",
+        "output": "/ch/5/config_color"
+    },
+    {
+        "input": "/ch/5/fdr",
+        "output": "/ch/5/mix_fader"
+    },
+    {
+        "input": "/ch/5/in/conn/altgrp",
+        "output": "/ch/5/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/5/in/conn/altin",
+        "output": "/ch/5/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/5/in/conn/grp",
+        "output": "/ch/5/input_conn_grp"
+    },
+    {
+        "input": "/ch/5/in/conn/in",
+        "output": "/ch/5/input_conn_in"
+    },
+    {
+        "input": "/ch/5/in/set/$g",
+        "output": "/ch/5/preamp_gain"
+    },
+    {
+        "input": "/ch/5/in/set/$mode",
+        "output": "/ch/5/input_mode"
+    },
+    {
+        "input": "/ch/5/in/set/$vph",
+        "output": "/ch/5/preamp_phantom"
+    },
+    {
+        "input": "/ch/5/in/set/altsrc",
+        "output": "/ch/5/input_altsrc"
+    },
+    {
+        "input": "/ch/5/in/set/bal",
+        "output": "/ch/5/input_balance"
+    },
+    {
+        "input": "/ch/5/in/set/dly",
+        "output": "/ch/5/input_delay"
+    },
+    {
+        "input": "/ch/5/in/set/dlymode",
+        "output": "/ch/5/input_delay_mode"
+    },
+    {
+        "input": "/ch/5/in/set/dlyon",
+        "output": "/ch/5/input_delay_on"
+    },
+    {
+        "input": "/ch/5/in/set/inv",
+        "output": "/ch/5/input_invert"
+    },
+    {
+        "input": "/ch/5/in/set/srcauto",
+        "output": "/ch/5/input_srcauto"
+    },
+    {
+        "input": "/ch/5/in/set/trim",
+        "output": "/ch/5/input_trim"
+    },
+    {
+        "input": "/ch/5/mute",
+        "output": "/ch/5/mix_on"
+    },
+    {
+        "input": "/ch/5/name",
+        "output": "/ch/5/config_name"
+    },
+    {
+        "input": "/ch/5/send/1/lvl",
+        "output": "/chsend/5/1/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/1/on",
+        "output": "/chsend/5/1/mix_on"
+    },
+    {
+        "input": "/ch/5/send/10/lvl",
+        "output": "/chsend/5/10/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/10/on",
+        "output": "/chsend/5/10/mix_on"
+    },
+    {
+        "input": "/ch/5/send/11/lvl",
+        "output": "/chsend/5/11/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/11/on",
+        "output": "/chsend/5/11/mix_on"
+    },
+    {
+        "input": "/ch/5/send/12/lvl",
+        "output": "/chsend/5/12/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/12/on",
+        "output": "/chsend/5/12/mix_on"
+    },
+    {
+        "input": "/ch/5/send/13/lvl",
+        "output": "/chsend/5/13/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/13/on",
+        "output": "/chsend/5/13/mix_on"
+    },
+    {
+        "input": "/ch/5/send/14/lvl",
+        "output": "/chsend/5/14/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/14/on",
+        "output": "/chsend/5/14/mix_on"
+    },
+    {
+        "input": "/ch/5/send/15/lvl",
+        "output": "/chsend/5/15/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/15/on",
+        "output": "/chsend/5/15/mix_on"
+    },
+    {
+        "input": "/ch/5/send/16/lvl",
+        "output": "/chsend/5/16/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/16/on",
+        "output": "/chsend/5/16/mix_on"
+    },
+    {
+        "input": "/ch/5/send/2/lvl",
+        "output": "/chsend/5/2/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/2/on",
+        "output": "/chsend/5/2/mix_on"
+    },
+    {
+        "input": "/ch/5/send/3/lvl",
+        "output": "/chsend/5/3/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/3/on",
+        "output": "/chsend/5/3/mix_on"
+    },
+    {
+        "input": "/ch/5/send/4/lvl",
+        "output": "/chsend/5/4/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/4/on",
+        "output": "/chsend/5/4/mix_on"
+    },
+    {
+        "input": "/ch/5/send/5/lvl",
+        "output": "/chsend/5/5/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/5/on",
+        "output": "/chsend/5/5/mix_on"
+    },
+    {
+        "input": "/ch/5/send/6/lvl",
+        "output": "/chsend/5/6/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/6/on",
+        "output": "/chsend/5/6/mix_on"
+    },
+    {
+        "input": "/ch/5/send/7/lvl",
+        "output": "/chsend/5/7/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/7/on",
+        "output": "/chsend/5/7/mix_on"
+    },
+    {
+        "input": "/ch/5/send/8/lvl",
+        "output": "/chsend/5/8/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/8/on",
+        "output": "/chsend/5/8/mix_on"
+    },
+    {
+        "input": "/ch/5/send/9/lvl",
+        "output": "/chsend/5/9/mix_fader"
+    },
+    {
+        "input": "/ch/5/send/9/on",
+        "output": "/chsend/5/9/mix_on"
+    },
+    {
+        "input": "/ch/6/col",
+        "output": "/ch/6/config_color"
+    },
+    {
+        "input": "/ch/6/fdr",
+        "output": "/ch/6/mix_fader"
+    },
+    {
+        "input": "/ch/6/in/conn/altgrp",
+        "output": "/ch/6/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/6/in/conn/altin",
+        "output": "/ch/6/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/6/in/conn/grp",
+        "output": "/ch/6/input_conn_grp"
+    },
+    {
+        "input": "/ch/6/in/conn/in",
+        "output": "/ch/6/input_conn_in"
+    },
+    {
+        "input": "/ch/6/in/set/$g",
+        "output": "/ch/6/preamp_gain"
+    },
+    {
+        "input": "/ch/6/in/set/$mode",
+        "output": "/ch/6/input_mode"
+    },
+    {
+        "input": "/ch/6/in/set/$vph",
+        "output": "/ch/6/preamp_phantom"
+    },
+    {
+        "input": "/ch/6/in/set/altsrc",
+        "output": "/ch/6/input_altsrc"
+    },
+    {
+        "input": "/ch/6/in/set/bal",
+        "output": "/ch/6/input_balance"
+    },
+    {
+        "input": "/ch/6/in/set/dly",
+        "output": "/ch/6/input_delay"
+    },
+    {
+        "input": "/ch/6/in/set/dlymode",
+        "output": "/ch/6/input_delay_mode"
+    },
+    {
+        "input": "/ch/6/in/set/dlyon",
+        "output": "/ch/6/input_delay_on"
+    },
+    {
+        "input": "/ch/6/in/set/inv",
+        "output": "/ch/6/input_invert"
+    },
+    {
+        "input": "/ch/6/in/set/srcauto",
+        "output": "/ch/6/input_srcauto"
+    },
+    {
+        "input": "/ch/6/in/set/trim",
+        "output": "/ch/6/input_trim"
+    },
+    {
+        "input": "/ch/6/mute",
+        "output": "/ch/6/mix_on"
+    },
+    {
+        "input": "/ch/6/name",
+        "output": "/ch/6/config_name"
+    },
+    {
+        "input": "/ch/6/send/1/lvl",
+        "output": "/chsend/6/1/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/1/on",
+        "output": "/chsend/6/1/mix_on"
+    },
+    {
+        "input": "/ch/6/send/10/lvl",
+        "output": "/chsend/6/10/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/10/on",
+        "output": "/chsend/6/10/mix_on"
+    },
+    {
+        "input": "/ch/6/send/11/lvl",
+        "output": "/chsend/6/11/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/11/on",
+        "output": "/chsend/6/11/mix_on"
+    },
+    {
+        "input": "/ch/6/send/12/lvl",
+        "output": "/chsend/6/12/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/12/on",
+        "output": "/chsend/6/12/mix_on"
+    },
+    {
+        "input": "/ch/6/send/13/lvl",
+        "output": "/chsend/6/13/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/13/on",
+        "output": "/chsend/6/13/mix_on"
+    },
+    {
+        "input": "/ch/6/send/14/lvl",
+        "output": "/chsend/6/14/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/14/on",
+        "output": "/chsend/6/14/mix_on"
+    },
+    {
+        "input": "/ch/6/send/15/lvl",
+        "output": "/chsend/6/15/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/15/on",
+        "output": "/chsend/6/15/mix_on"
+    },
+    {
+        "input": "/ch/6/send/16/lvl",
+        "output": "/chsend/6/16/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/16/on",
+        "output": "/chsend/6/16/mix_on"
+    },
+    {
+        "input": "/ch/6/send/2/lvl",
+        "output": "/chsend/6/2/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/2/on",
+        "output": "/chsend/6/2/mix_on"
+    },
+    {
+        "input": "/ch/6/send/3/lvl",
+        "output": "/chsend/6/3/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/3/on",
+        "output": "/chsend/6/3/mix_on"
+    },
+    {
+        "input": "/ch/6/send/4/lvl",
+        "output": "/chsend/6/4/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/4/on",
+        "output": "/chsend/6/4/mix_on"
+    },
+    {
+        "input": "/ch/6/send/5/lvl",
+        "output": "/chsend/6/5/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/5/on",
+        "output": "/chsend/6/5/mix_on"
+    },
+    {
+        "input": "/ch/6/send/6/lvl",
+        "output": "/chsend/6/6/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/6/on",
+        "output": "/chsend/6/6/mix_on"
+    },
+    {
+        "input": "/ch/6/send/7/lvl",
+        "output": "/chsend/6/7/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/7/on",
+        "output": "/chsend/6/7/mix_on"
+    },
+    {
+        "input": "/ch/6/send/8/lvl",
+        "output": "/chsend/6/8/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/8/on",
+        "output": "/chsend/6/8/mix_on"
+    },
+    {
+        "input": "/ch/6/send/9/lvl",
+        "output": "/chsend/6/9/mix_fader"
+    },
+    {
+        "input": "/ch/6/send/9/on",
+        "output": "/chsend/6/9/mix_on"
+    },
+    {
+        "input": "/ch/7/col",
+        "output": "/ch/7/config_color"
+    },
+    {
+        "input": "/ch/7/fdr",
+        "output": "/ch/7/mix_fader"
+    },
+    {
+        "input": "/ch/7/in/conn/altgrp",
+        "output": "/ch/7/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/7/in/conn/altin",
+        "output": "/ch/7/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/7/in/conn/grp",
+        "output": "/ch/7/input_conn_grp"
+    },
+    {
+        "input": "/ch/7/in/conn/in",
+        "output": "/ch/7/input_conn_in"
+    },
+    {
+        "input": "/ch/7/in/set/$g",
+        "output": "/ch/7/preamp_gain"
+    },
+    {
+        "input": "/ch/7/in/set/$mode",
+        "output": "/ch/7/input_mode"
+    },
+    {
+        "input": "/ch/7/in/set/$vph",
+        "output": "/ch/7/preamp_phantom"
+    },
+    {
+        "input": "/ch/7/in/set/altsrc",
+        "output": "/ch/7/input_altsrc"
+    },
+    {
+        "input": "/ch/7/in/set/bal",
+        "output": "/ch/7/input_balance"
+    },
+    {
+        "input": "/ch/7/in/set/dly",
+        "output": "/ch/7/input_delay"
+    },
+    {
+        "input": "/ch/7/in/set/dlymode",
+        "output": "/ch/7/input_delay_mode"
+    },
+    {
+        "input": "/ch/7/in/set/dlyon",
+        "output": "/ch/7/input_delay_on"
+    },
+    {
+        "input": "/ch/7/in/set/inv",
+        "output": "/ch/7/input_invert"
+    },
+    {
+        "input": "/ch/7/in/set/srcauto",
+        "output": "/ch/7/input_srcauto"
+    },
+    {
+        "input": "/ch/7/in/set/trim",
+        "output": "/ch/7/input_trim"
+    },
+    {
+        "input": "/ch/7/mute",
+        "output": "/ch/7/mix_on"
+    },
+    {
+        "input": "/ch/7/name",
+        "output": "/ch/7/config_name"
+    },
+    {
+        "input": "/ch/7/send/1/lvl",
+        "output": "/chsend/7/1/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/1/on",
+        "output": "/chsend/7/1/mix_on"
+    },
+    {
+        "input": "/ch/7/send/10/lvl",
+        "output": "/chsend/7/10/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/10/on",
+        "output": "/chsend/7/10/mix_on"
+    },
+    {
+        "input": "/ch/7/send/11/lvl",
+        "output": "/chsend/7/11/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/11/on",
+        "output": "/chsend/7/11/mix_on"
+    },
+    {
+        "input": "/ch/7/send/12/lvl",
+        "output": "/chsend/7/12/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/12/on",
+        "output": "/chsend/7/12/mix_on"
+    },
+    {
+        "input": "/ch/7/send/13/lvl",
+        "output": "/chsend/7/13/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/13/on",
+        "output": "/chsend/7/13/mix_on"
+    },
+    {
+        "input": "/ch/7/send/14/lvl",
+        "output": "/chsend/7/14/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/14/on",
+        "output": "/chsend/7/14/mix_on"
+    },
+    {
+        "input": "/ch/7/send/15/lvl",
+        "output": "/chsend/7/15/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/15/on",
+        "output": "/chsend/7/15/mix_on"
+    },
+    {
+        "input": "/ch/7/send/16/lvl",
+        "output": "/chsend/7/16/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/16/on",
+        "output": "/chsend/7/16/mix_on"
+    },
+    {
+        "input": "/ch/7/send/2/lvl",
+        "output": "/chsend/7/2/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/2/on",
+        "output": "/chsend/7/2/mix_on"
+    },
+    {
+        "input": "/ch/7/send/3/lvl",
+        "output": "/chsend/7/3/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/3/on",
+        "output": "/chsend/7/3/mix_on"
+    },
+    {
+        "input": "/ch/7/send/4/lvl",
+        "output": "/chsend/7/4/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/4/on",
+        "output": "/chsend/7/4/mix_on"
+    },
+    {
+        "input": "/ch/7/send/5/lvl",
+        "output": "/chsend/7/5/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/5/on",
+        "output": "/chsend/7/5/mix_on"
+    },
+    {
+        "input": "/ch/7/send/6/lvl",
+        "output": "/chsend/7/6/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/6/on",
+        "output": "/chsend/7/6/mix_on"
+    },
+    {
+        "input": "/ch/7/send/7/lvl",
+        "output": "/chsend/7/7/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/7/on",
+        "output": "/chsend/7/7/mix_on"
+    },
+    {
+        "input": "/ch/7/send/8/lvl",
+        "output": "/chsend/7/8/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/8/on",
+        "output": "/chsend/7/8/mix_on"
+    },
+    {
+        "input": "/ch/7/send/9/lvl",
+        "output": "/chsend/7/9/mix_fader"
+    },
+    {
+        "input": "/ch/7/send/9/on",
+        "output": "/chsend/7/9/mix_on"
+    },
+    {
+        "input": "/ch/8/col",
+        "output": "/ch/8/config_color"
+    },
+    {
+        "input": "/ch/8/fdr",
+        "output": "/ch/8/mix_fader"
+    },
+    {
+        "input": "/ch/8/in/conn/altgrp",
+        "output": "/ch/8/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/8/in/conn/altin",
+        "output": "/ch/8/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/8/in/conn/grp",
+        "output": "/ch/8/input_conn_grp"
+    },
+    {
+        "input": "/ch/8/in/conn/in",
+        "output": "/ch/8/input_conn_in"
+    },
+    {
+        "input": "/ch/8/in/set/$g",
+        "output": "/ch/8/preamp_gain"
+    },
+    {
+        "input": "/ch/8/in/set/$mode",
+        "output": "/ch/8/input_mode"
+    },
+    {
+        "input": "/ch/8/in/set/$vph",
+        "output": "/ch/8/preamp_phantom"
+    },
+    {
+        "input": "/ch/8/in/set/altsrc",
+        "output": "/ch/8/input_altsrc"
+    },
+    {
+        "input": "/ch/8/in/set/bal",
+        "output": "/ch/8/input_balance"
+    },
+    {
+        "input": "/ch/8/in/set/dly",
+        "output": "/ch/8/input_delay"
+    },
+    {
+        "input": "/ch/8/in/set/dlymode",
+        "output": "/ch/8/input_delay_mode"
+    },
+    {
+        "input": "/ch/8/in/set/dlyon",
+        "output": "/ch/8/input_delay_on"
+    },
+    {
+        "input": "/ch/8/in/set/inv",
+        "output": "/ch/8/input_invert"
+    },
+    {
+        "input": "/ch/8/in/set/srcauto",
+        "output": "/ch/8/input_srcauto"
+    },
+    {
+        "input": "/ch/8/in/set/trim",
+        "output": "/ch/8/input_trim"
+    },
+    {
+        "input": "/ch/8/mute",
+        "output": "/ch/8/mix_on"
+    },
+    {
+        "input": "/ch/8/name",
+        "output": "/ch/8/config_name"
+    },
+    {
+        "input": "/ch/8/send/1/lvl",
+        "output": "/chsend/8/1/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/1/on",
+        "output": "/chsend/8/1/mix_on"
+    },
+    {
+        "input": "/ch/8/send/10/lvl",
+        "output": "/chsend/8/10/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/10/on",
+        "output": "/chsend/8/10/mix_on"
+    },
+    {
+        "input": "/ch/8/send/11/lvl",
+        "output": "/chsend/8/11/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/11/on",
+        "output": "/chsend/8/11/mix_on"
+    },
+    {
+        "input": "/ch/8/send/12/lvl",
+        "output": "/chsend/8/12/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/12/on",
+        "output": "/chsend/8/12/mix_on"
+    },
+    {
+        "input": "/ch/8/send/13/lvl",
+        "output": "/chsend/8/13/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/13/on",
+        "output": "/chsend/8/13/mix_on"
+    },
+    {
+        "input": "/ch/8/send/14/lvl",
+        "output": "/chsend/8/14/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/14/on",
+        "output": "/chsend/8/14/mix_on"
+    },
+    {
+        "input": "/ch/8/send/15/lvl",
+        "output": "/chsend/8/15/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/15/on",
+        "output": "/chsend/8/15/mix_on"
+    },
+    {
+        "input": "/ch/8/send/16/lvl",
+        "output": "/chsend/8/16/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/16/on",
+        "output": "/chsend/8/16/mix_on"
+    },
+    {
+        "input": "/ch/8/send/2/lvl",
+        "output": "/chsend/8/2/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/2/on",
+        "output": "/chsend/8/2/mix_on"
+    },
+    {
+        "input": "/ch/8/send/3/lvl",
+        "output": "/chsend/8/3/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/3/on",
+        "output": "/chsend/8/3/mix_on"
+    },
+    {
+        "input": "/ch/8/send/4/lvl",
+        "output": "/chsend/8/4/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/4/on",
+        "output": "/chsend/8/4/mix_on"
+    },
+    {
+        "input": "/ch/8/send/5/lvl",
+        "output": "/chsend/8/5/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/5/on",
+        "output": "/chsend/8/5/mix_on"
+    },
+    {
+        "input": "/ch/8/send/6/lvl",
+        "output": "/chsend/8/6/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/6/on",
+        "output": "/chsend/8/6/mix_on"
+    },
+    {
+        "input": "/ch/8/send/7/lvl",
+        "output": "/chsend/8/7/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/7/on",
+        "output": "/chsend/8/7/mix_on"
+    },
+    {
+        "input": "/ch/8/send/8/lvl",
+        "output": "/chsend/8/8/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/8/on",
+        "output": "/chsend/8/8/mix_on"
+    },
+    {
+        "input": "/ch/8/send/9/lvl",
+        "output": "/chsend/8/9/mix_fader"
+    },
+    {
+        "input": "/ch/8/send/9/on",
+        "output": "/chsend/8/9/mix_on"
+    },
+    {
+        "input": "/ch/9/col",
+        "output": "/ch/9/config_color"
+    },
+    {
+        "input": "/ch/9/fdr",
+        "output": "/ch/9/mix_fader"
+    },
+    {
+        "input": "/ch/9/in/conn/altgrp",
+        "output": "/ch/9/input_alt_conn_grp"
+    },
+    {
+        "input": "/ch/9/in/conn/altin",
+        "output": "/ch/9/input_alt_conn_in"
+    },
+    {
+        "input": "/ch/9/in/conn/grp",
+        "output": "/ch/9/input_conn_grp"
+    },
+    {
+        "input": "/ch/9/in/conn/in",
+        "output": "/ch/9/input_conn_in"
+    },
+    {
+        "input": "/ch/9/in/set/$g",
+        "output": "/ch/9/preamp_gain"
+    },
+    {
+        "input": "/ch/9/in/set/$mode",
+        "output": "/ch/9/input_mode"
+    },
+    {
+        "input": "/ch/9/in/set/$vph",
+        "output": "/ch/9/preamp_phantom"
+    },
+    {
+        "input": "/ch/9/in/set/altsrc",
+        "output": "/ch/9/input_altsrc"
+    },
+    {
+        "input": "/ch/9/in/set/bal",
+        "output": "/ch/9/input_balance"
+    },
+    {
+        "input": "/ch/9/in/set/dly",
+        "output": "/ch/9/input_delay"
+    },
+    {
+        "input": "/ch/9/in/set/dlymode",
+        "output": "/ch/9/input_delay_mode"
+    },
+    {
+        "input": "/ch/9/in/set/dlyon",
+        "output": "/ch/9/input_delay_on"
+    },
+    {
+        "input": "/ch/9/in/set/inv",
+        "output": "/ch/9/input_invert"
+    },
+    {
+        "input": "/ch/9/in/set/srcauto",
+        "output": "/ch/9/input_srcauto"
+    },
+    {
+        "input": "/ch/9/in/set/trim",
+        "output": "/ch/9/input_trim"
+    },
+    {
+        "input": "/ch/9/mute",
+        "output": "/ch/9/mix_on"
+    },
+    {
+        "input": "/ch/9/name",
+        "output": "/ch/9/config_name"
+    },
+    {
+        "input": "/ch/9/send/1/lvl",
+        "output": "/chsend/9/1/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/1/on",
+        "output": "/chsend/9/1/mix_on"
+    },
+    {
+        "input": "/ch/9/send/10/lvl",
+        "output": "/chsend/9/10/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/10/on",
+        "output": "/chsend/9/10/mix_on"
+    },
+    {
+        "input": "/ch/9/send/11/lvl",
+        "output": "/chsend/9/11/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/11/on",
+        "output": "/chsend/9/11/mix_on"
+    },
+    {
+        "input": "/ch/9/send/12/lvl",
+        "output": "/chsend/9/12/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/12/on",
+        "output": "/chsend/9/12/mix_on"
+    },
+    {
+        "input": "/ch/9/send/13/lvl",
+        "output": "/chsend/9/13/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/13/on",
+        "output": "/chsend/9/13/mix_on"
+    },
+    {
+        "input": "/ch/9/send/14/lvl",
+        "output": "/chsend/9/14/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/14/on",
+        "output": "/chsend/9/14/mix_on"
+    },
+    {
+        "input": "/ch/9/send/15/lvl",
+        "output": "/chsend/9/15/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/15/on",
+        "output": "/chsend/9/15/mix_on"
+    },
+    {
+        "input": "/ch/9/send/16/lvl",
+        "output": "/chsend/9/16/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/16/on",
+        "output": "/chsend/9/16/mix_on"
+    },
+    {
+        "input": "/ch/9/send/2/lvl",
+        "output": "/chsend/9/2/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/2/on",
+        "output": "/chsend/9/2/mix_on"
+    },
+    {
+        "input": "/ch/9/send/3/lvl",
+        "output": "/chsend/9/3/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/3/on",
+        "output": "/chsend/9/3/mix_on"
+    },
+    {
+        "input": "/ch/9/send/4/lvl",
+        "output": "/chsend/9/4/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/4/on",
+        "output": "/chsend/9/4/mix_on"
+    },
+    {
+        "input": "/ch/9/send/5/lvl",
+        "output": "/chsend/9/5/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/5/on",
+        "output": "/chsend/9/5/mix_on"
+    },
+    {
+        "input": "/ch/9/send/6/lvl",
+        "output": "/chsend/9/6/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/6/on",
+        "output": "/chsend/9/6/mix_on"
+    },
+    {
+        "input": "/ch/9/send/7/lvl",
+        "output": "/chsend/9/7/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/7/on",
+        "output": "/chsend/9/7/mix_on"
+    },
+    {
+        "input": "/ch/9/send/8/lvl",
+        "output": "/chsend/9/8/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/8/on",
+        "output": "/chsend/9/8/mix_on"
+    },
+    {
+        "input": "/ch/9/send/9/lvl",
+        "output": "/chsend/9/9/mix_fader"
+    },
+    {
+        "input": "/ch/9/send/9/on",
+        "output": "/chsend/9/9/mix_on"
+    },
+    {
+        "input": "/dca/1/col",
+        "output": "/dca/1/config_color"
+    },
+    {
+        "input": "/dca/1/fdr",
+        "output": "/dca/1/mix_fader"
+    },
+    {
+        "input": "/dca/1/mute",
+        "output": "/dca/1/mix_on"
+    },
+    {
+        "input": "/dca/1/name",
+        "output": "/dca/1/config_name"
+    },
+    {
+        "input": "/dca/10/col",
+        "output": "/dca/10/config_color"
+    },
+    {
+        "input": "/dca/10/fdr",
+        "output": "/dca/10/mix_fader"
+    },
+    {
+        "input": "/dca/10/mute",
+        "output": "/dca/10/mix_on"
+    },
+    {
+        "input": "/dca/10/name",
+        "output": "/dca/10/config_name"
+    },
+    {
+        "input": "/dca/11/col",
+        "output": "/dca/11/config_color"
+    },
+    {
+        "input": "/dca/11/fdr",
+        "output": "/dca/11/mix_fader"
+    },
+    {
+        "input": "/dca/11/mute",
+        "output": "/dca/11/mix_on"
+    },
+    {
+        "input": "/dca/11/name",
+        "output": "/dca/11/config_name"
+    },
+    {
+        "input": "/dca/12/col",
+        "output": "/dca/12/config_color"
+    },
+    {
+        "input": "/dca/12/fdr",
+        "output": "/dca/12/mix_fader"
+    },
+    {
+        "input": "/dca/12/mute",
+        "output": "/dca/12/mix_on"
+    },
+    {
+        "input": "/dca/12/name",
+        "output": "/dca/12/config_name"
+    },
+    {
+        "input": "/dca/13/col",
+        "output": "/dca/13/config_color"
+    },
+    {
+        "input": "/dca/13/fdr",
+        "output": "/dca/13/mix_fader"
+    },
+    {
+        "input": "/dca/13/mute",
+        "output": "/dca/13/mix_on"
+    },
+    {
+        "input": "/dca/13/name",
+        "output": "/dca/13/config_name"
+    },
+    {
+        "input": "/dca/14/col",
+        "output": "/dca/14/config_color"
+    },
+    {
+        "input": "/dca/14/fdr",
+        "output": "/dca/14/mix_fader"
+    },
+    {
+        "input": "/dca/14/mute",
+        "output": "/dca/14/mix_on"
+    },
+    {
+        "input": "/dca/14/name",
+        "output": "/dca/14/config_name"
+    },
+    {
+        "input": "/dca/15/col",
+        "output": "/dca/15/config_color"
+    },
+    {
+        "input": "/dca/15/fdr",
+        "output": "/dca/15/mix_fader"
+    },
+    {
+        "input": "/dca/15/mute",
+        "output": "/dca/15/mix_on"
+    },
+    {
+        "input": "/dca/15/name",
+        "output": "/dca/15/config_name"
+    },
+    {
+        "input": "/dca/16/col",
+        "output": "/dca/16/config_color"
+    },
+    {
+        "input": "/dca/16/fdr",
+        "output": "/dca/16/mix_fader"
+    },
+    {
+        "input": "/dca/16/mute",
+        "output": "/dca/16/mix_on"
+    },
+    {
+        "input": "/dca/16/name",
+        "output": "/dca/16/config_name"
+    },
+    {
+        "input": "/dca/2/col",
+        "output": "/dca/2/config_color"
+    },
+    {
+        "input": "/dca/2/fdr",
+        "output": "/dca/2/mix_fader"
+    },
+    {
+        "input": "/dca/2/mute",
+        "output": "/dca/2/mix_on"
+    },
+    {
+        "input": "/dca/2/name",
+        "output": "/dca/2/config_name"
+    },
+    {
+        "input": "/dca/3/col",
+        "output": "/dca/3/config_color"
+    },
+    {
+        "input": "/dca/3/fdr",
+        "output": "/dca/3/mix_fader"
+    },
+    {
+        "input": "/dca/3/mute",
+        "output": "/dca/3/mix_on"
+    },
+    {
+        "input": "/dca/3/name",
+        "output": "/dca/3/config_name"
+    },
+    {
+        "input": "/dca/4/col",
+        "output": "/dca/4/config_color"
+    },
+    {
+        "input": "/dca/4/fdr",
+        "output": "/dca/4/mix_fader"
+    },
+    {
+        "input": "/dca/4/mute",
+        "output": "/dca/4/mix_on"
+    },
+    {
+        "input": "/dca/4/name",
+        "output": "/dca/4/config_name"
+    },
+    {
+        "input": "/dca/5/col",
+        "output": "/dca/5/config_color"
+    },
+    {
+        "input": "/dca/5/fdr",
+        "output": "/dca/5/mix_fader"
+    },
+    {
+        "input": "/dca/5/mute",
+        "output": "/dca/5/mix_on"
+    },
+    {
+        "input": "/dca/5/name",
+        "output": "/dca/5/config_name"
+    },
+    {
+        "input": "/dca/6/col",
+        "output": "/dca/6/config_color"
+    },
+    {
+        "input": "/dca/6/fdr",
+        "output": "/dca/6/mix_fader"
+    },
+    {
+        "input": "/dca/6/mute",
+        "output": "/dca/6/mix_on"
+    },
+    {
+        "input": "/dca/6/name",
+        "output": "/dca/6/config_name"
+    },
+    {
+        "input": "/dca/7/col",
+        "output": "/dca/7/config_color"
+    },
+    {
+        "input": "/dca/7/fdr",
+        "output": "/dca/7/mix_fader"
+    },
+    {
+        "input": "/dca/7/mute",
+        "output": "/dca/7/mix_on"
+    },
+    {
+        "input": "/dca/7/name",
+        "output": "/dca/7/config_name"
+    },
+    {
+        "input": "/dca/8/col",
+        "output": "/dca/8/config_color"
+    },
+    {
+        "input": "/dca/8/fdr",
+        "output": "/dca/8/mix_fader"
+    },
+    {
+        "input": "/dca/8/mute",
+        "output": "/dca/8/mix_on"
+    },
+    {
+        "input": "/dca/8/name",
+        "output": "/dca/8/config_name"
+    },
+    {
+        "input": "/dca/9/col",
+        "output": "/dca/9/config_color"
+    },
+    {
+        "input": "/dca/9/fdr",
+        "output": "/dca/9/mix_fader"
+    },
+    {
+        "input": "/dca/9/mute",
+        "output": "/dca/9/mix_on"
+    },
+    {
+        "input": "/dca/9/name",
+        "output": "/dca/9/config_name"
+    },
+    {
+        "input": "/io/in/A/1/col",
+        "output": "/headamp/a/1/config_color"
+    },
+    {
+        "input": "/io/in/A/1/g",
+        "output": "/headamp/a/1/gain"
+    },
+    {
+        "input": "/io/in/A/1/name",
+        "output": "/headamp/a/1/config_name"
+    },
+    {
+        "input": "/io/in/A/1/vph",
+        "output": "/headamp/a/1/phantom"
+    },
+    {
+        "input": "/io/in/A/10/col",
+        "output": "/headamp/a/10/config_color"
+    },
+    {
+        "input": "/io/in/A/10/g",
+        "output": "/headamp/a/10/gain"
+    },
+    {
+        "input": "/io/in/A/10/name",
+        "output": "/headamp/a/10/config_name"
+    },
+    {
+        "input": "/io/in/A/10/vph",
+        "output": "/headamp/a/10/phantom"
+    },
+    {
+        "input": "/io/in/A/11/col",
+        "output": "/headamp/a/11/config_color"
+    },
+    {
+        "input": "/io/in/A/11/g",
+        "output": "/headamp/a/11/gain"
+    },
+    {
+        "input": "/io/in/A/11/name",
+        "output": "/headamp/a/11/config_name"
+    },
+    {
+        "input": "/io/in/A/11/vph",
+        "output": "/headamp/a/11/phantom"
+    },
+    {
+        "input": "/io/in/A/12/col",
+        "output": "/headamp/a/12/config_color"
+    },
+    {
+        "input": "/io/in/A/12/g",
+        "output": "/headamp/a/12/gain"
+    },
+    {
+        "input": "/io/in/A/12/name",
+        "output": "/headamp/a/12/config_name"
+    },
+    {
+        "input": "/io/in/A/12/vph",
+        "output": "/headamp/a/12/phantom"
+    },
+    {
+        "input": "/io/in/A/13/col",
+        "output": "/headamp/a/13/config_color"
+    },
+    {
+        "input": "/io/in/A/13/g",
+        "output": "/headamp/a/13/gain"
+    },
+    {
+        "input": "/io/in/A/13/name",
+        "output": "/headamp/a/13/config_name"
+    },
+    {
+        "input": "/io/in/A/13/vph",
+        "output": "/headamp/a/13/phantom"
+    },
+    {
+        "input": "/io/in/A/14/col",
+        "output": "/headamp/a/14/config_color"
+    },
+    {
+        "input": "/io/in/A/14/g",
+        "output": "/headamp/a/14/gain"
+    },
+    {
+        "input": "/io/in/A/14/name",
+        "output": "/headamp/a/14/config_name"
+    },
+    {
+        "input": "/io/in/A/14/vph",
+        "output": "/headamp/a/14/phantom"
+    },
+    {
+        "input": "/io/in/A/15/col",
+        "output": "/headamp/a/15/config_color"
+    },
+    {
+        "input": "/io/in/A/15/g",
+        "output": "/headamp/a/15/gain"
+    },
+    {
+        "input": "/io/in/A/15/name",
+        "output": "/headamp/a/15/config_name"
+    },
+    {
+        "input": "/io/in/A/15/vph",
+        "output": "/headamp/a/15/phantom"
+    },
+    {
+        "input": "/io/in/A/16/col",
+        "output": "/headamp/a/16/config_color"
+    },
+    {
+        "input": "/io/in/A/16/g",
+        "output": "/headamp/a/16/gain"
+    },
+    {
+        "input": "/io/in/A/16/name",
+        "output": "/headamp/a/16/config_name"
+    },
+    {
+        "input": "/io/in/A/16/vph",
+        "output": "/headamp/a/16/phantom"
+    },
+    {
+        "input": "/io/in/A/17/col",
+        "output": "/headamp/a/17/config_color"
+    },
+    {
+        "input": "/io/in/A/17/g",
+        "output": "/headamp/a/17/gain"
+    },
+    {
+        "input": "/io/in/A/17/name",
+        "output": "/headamp/a/17/config_name"
+    },
+    {
+        "input": "/io/in/A/17/vph",
+        "output": "/headamp/a/17/phantom"
+    },
+    {
+        "input": "/io/in/A/18/col",
+        "output": "/headamp/a/18/config_color"
+    },
+    {
+        "input": "/io/in/A/18/g",
+        "output": "/headamp/a/18/gain"
+    },
+    {
+        "input": "/io/in/A/18/name",
+        "output": "/headamp/a/18/config_name"
+    },
+    {
+        "input": "/io/in/A/18/vph",
+        "output": "/headamp/a/18/phantom"
+    },
+    {
+        "input": "/io/in/A/19/col",
+        "output": "/headamp/a/19/config_color"
+    },
+    {
+        "input": "/io/in/A/19/g",
+        "output": "/headamp/a/19/gain"
+    },
+    {
+        "input": "/io/in/A/19/name",
+        "output": "/headamp/a/19/config_name"
+    },
+    {
+        "input": "/io/in/A/19/vph",
+        "output": "/headamp/a/19/phantom"
+    },
+    {
+        "input": "/io/in/A/2/col",
+        "output": "/headamp/a/2/config_color"
+    },
+    {
+        "input": "/io/in/A/2/g",
+        "output": "/headamp/a/2/gain"
+    },
+    {
+        "input": "/io/in/A/2/name",
+        "output": "/headamp/a/2/config_name"
+    },
+    {
+        "input": "/io/in/A/2/vph",
+        "output": "/headamp/a/2/phantom"
+    },
+    {
+        "input": "/io/in/A/20/col",
+        "output": "/headamp/a/20/config_color"
+    },
+    {
+        "input": "/io/in/A/20/g",
+        "output": "/headamp/a/20/gain"
+    },
+    {
+        "input": "/io/in/A/20/name",
+        "output": "/headamp/a/20/config_name"
+    },
+    {
+        "input": "/io/in/A/20/vph",
+        "output": "/headamp/a/20/phantom"
+    },
+    {
+        "input": "/io/in/A/21/col",
+        "output": "/headamp/a/21/config_color"
+    },
+    {
+        "input": "/io/in/A/21/g",
+        "output": "/headamp/a/21/gain"
+    },
+    {
+        "input": "/io/in/A/21/name",
+        "output": "/headamp/a/21/config_name"
+    },
+    {
+        "input": "/io/in/A/21/vph",
+        "output": "/headamp/a/21/phantom"
+    },
+    {
+        "input": "/io/in/A/22/col",
+        "output": "/headamp/a/22/config_color"
+    },
+    {
+        "input": "/io/in/A/22/g",
+        "output": "/headamp/a/22/gain"
+    },
+    {
+        "input": "/io/in/A/22/name",
+        "output": "/headamp/a/22/config_name"
+    },
+    {
+        "input": "/io/in/A/22/vph",
+        "output": "/headamp/a/22/phantom"
+    },
+    {
+        "input": "/io/in/A/23/col",
+        "output": "/headamp/a/23/config_color"
+    },
+    {
+        "input": "/io/in/A/23/g",
+        "output": "/headamp/a/23/gain"
+    },
+    {
+        "input": "/io/in/A/23/name",
+        "output": "/headamp/a/23/config_name"
+    },
+    {
+        "input": "/io/in/A/23/vph",
+        "output": "/headamp/a/23/phantom"
+    },
+    {
+        "input": "/io/in/A/24/col",
+        "output": "/headamp/a/24/config_color"
+    },
+    {
+        "input": "/io/in/A/24/g",
+        "output": "/headamp/a/24/gain"
+    },
+    {
+        "input": "/io/in/A/24/name",
+        "output": "/headamp/a/24/config_name"
+    },
+    {
+        "input": "/io/in/A/24/vph",
+        "output": "/headamp/a/24/phantom"
+    },
+    {
+        "input": "/io/in/A/25/col",
+        "output": "/headamp/a/25/config_color"
+    },
+    {
+        "input": "/io/in/A/25/g",
+        "output": "/headamp/a/25/gain"
+    },
+    {
+        "input": "/io/in/A/25/name",
+        "output": "/headamp/a/25/config_name"
+    },
+    {
+        "input": "/io/in/A/25/vph",
+        "output": "/headamp/a/25/phantom"
+    },
+    {
+        "input": "/io/in/A/26/col",
+        "output": "/headamp/a/26/config_color"
+    },
+    {
+        "input": "/io/in/A/26/g",
+        "output": "/headamp/a/26/gain"
+    },
+    {
+        "input": "/io/in/A/26/name",
+        "output": "/headamp/a/26/config_name"
+    },
+    {
+        "input": "/io/in/A/26/vph",
+        "output": "/headamp/a/26/phantom"
+    },
+    {
+        "input": "/io/in/A/27/col",
+        "output": "/headamp/a/27/config_color"
+    },
+    {
+        "input": "/io/in/A/27/g",
+        "output": "/headamp/a/27/gain"
+    },
+    {
+        "input": "/io/in/A/27/name",
+        "output": "/headamp/a/27/config_name"
+    },
+    {
+        "input": "/io/in/A/27/vph",
+        "output": "/headamp/a/27/phantom"
+    },
+    {
+        "input": "/io/in/A/28/col",
+        "output": "/headamp/a/28/config_color"
+    },
+    {
+        "input": "/io/in/A/28/g",
+        "output": "/headamp/a/28/gain"
+    },
+    {
+        "input": "/io/in/A/28/name",
+        "output": "/headamp/a/28/config_name"
+    },
+    {
+        "input": "/io/in/A/28/vph",
+        "output": "/headamp/a/28/phantom"
+    },
+    {
+        "input": "/io/in/A/29/col",
+        "output": "/headamp/a/29/config_color"
+    },
+    {
+        "input": "/io/in/A/29/g",
+        "output": "/headamp/a/29/gain"
+    },
+    {
+        "input": "/io/in/A/29/name",
+        "output": "/headamp/a/29/config_name"
+    },
+    {
+        "input": "/io/in/A/29/vph",
+        "output": "/headamp/a/29/phantom"
+    },
+    {
+        "input": "/io/in/A/3/col",
+        "output": "/headamp/a/3/config_color"
+    },
+    {
+        "input": "/io/in/A/3/g",
+        "output": "/headamp/a/3/gain"
+    },
+    {
+        "input": "/io/in/A/3/name",
+        "output": "/headamp/a/3/config_name"
+    },
+    {
+        "input": "/io/in/A/3/vph",
+        "output": "/headamp/a/3/phantom"
+    },
+    {
+        "input": "/io/in/A/30/col",
+        "output": "/headamp/a/30/config_color"
+    },
+    {
+        "input": "/io/in/A/30/g",
+        "output": "/headamp/a/30/gain"
+    },
+    {
+        "input": "/io/in/A/30/name",
+        "output": "/headamp/a/30/config_name"
+    },
+    {
+        "input": "/io/in/A/30/vph",
+        "output": "/headamp/a/30/phantom"
+    },
+    {
+        "input": "/io/in/A/31/col",
+        "output": "/headamp/a/31/config_color"
+    },
+    {
+        "input": "/io/in/A/31/g",
+        "output": "/headamp/a/31/gain"
+    },
+    {
+        "input": "/io/in/A/31/name",
+        "output": "/headamp/a/31/config_name"
+    },
+    {
+        "input": "/io/in/A/31/vph",
+        "output": "/headamp/a/31/phantom"
+    },
+    {
+        "input": "/io/in/A/32/col",
+        "output": "/headamp/a/32/config_color"
+    },
+    {
+        "input": "/io/in/A/32/g",
+        "output": "/headamp/a/32/gain"
+    },
+    {
+        "input": "/io/in/A/32/name",
+        "output": "/headamp/a/32/config_name"
+    },
+    {
+        "input": "/io/in/A/32/vph",
+        "output": "/headamp/a/32/phantom"
+    },
+    {
+        "input": "/io/in/A/33/col",
+        "output": "/headamp/a/33/config_color"
+    },
+    {
+        "input": "/io/in/A/33/g",
+        "output": "/headamp/a/33/gain"
+    },
+    {
+        "input": "/io/in/A/33/name",
+        "output": "/headamp/a/33/config_name"
+    },
+    {
+        "input": "/io/in/A/33/vph",
+        "output": "/headamp/a/33/phantom"
+    },
+    {
+        "input": "/io/in/A/34/col",
+        "output": "/headamp/a/34/config_color"
+    },
+    {
+        "input": "/io/in/A/34/g",
+        "output": "/headamp/a/34/gain"
+    },
+    {
+        "input": "/io/in/A/34/name",
+        "output": "/headamp/a/34/config_name"
+    },
+    {
+        "input": "/io/in/A/34/vph",
+        "output": "/headamp/a/34/phantom"
+    },
+    {
+        "input": "/io/in/A/35/col",
+        "output": "/headamp/a/35/config_color"
+    },
+    {
+        "input": "/io/in/A/35/g",
+        "output": "/headamp/a/35/gain"
+    },
+    {
+        "input": "/io/in/A/35/name",
+        "output": "/headamp/a/35/config_name"
+    },
+    {
+        "input": "/io/in/A/35/vph",
+        "output": "/headamp/a/35/phantom"
+    },
+    {
+        "input": "/io/in/A/36/col",
+        "output": "/headamp/a/36/config_color"
+    },
+    {
+        "input": "/io/in/A/36/g",
+        "output": "/headamp/a/36/gain"
+    },
+    {
+        "input": "/io/in/A/36/name",
+        "output": "/headamp/a/36/config_name"
+    },
+    {
+        "input": "/io/in/A/36/vph",
+        "output": "/headamp/a/36/phantom"
+    },
+    {
+        "input": "/io/in/A/37/col",
+        "output": "/headamp/a/37/config_color"
+    },
+    {
+        "input": "/io/in/A/37/g",
+        "output": "/headamp/a/37/gain"
+    },
+    {
+        "input": "/io/in/A/37/name",
+        "output": "/headamp/a/37/config_name"
+    },
+    {
+        "input": "/io/in/A/37/vph",
+        "output": "/headamp/a/37/phantom"
+    },
+    {
+        "input": "/io/in/A/38/col",
+        "output": "/headamp/a/38/config_color"
+    },
+    {
+        "input": "/io/in/A/38/g",
+        "output": "/headamp/a/38/gain"
+    },
+    {
+        "input": "/io/in/A/38/name",
+        "output": "/headamp/a/38/config_name"
+    },
+    {
+        "input": "/io/in/A/38/vph",
+        "output": "/headamp/a/38/phantom"
+    },
+    {
+        "input": "/io/in/A/39/col",
+        "output": "/headamp/a/39/config_color"
+    },
+    {
+        "input": "/io/in/A/39/g",
+        "output": "/headamp/a/39/gain"
+    },
+    {
+        "input": "/io/in/A/39/name",
+        "output": "/headamp/a/39/config_name"
+    },
+    {
+        "input": "/io/in/A/39/vph",
+        "output": "/headamp/a/39/phantom"
+    },
+    {
+        "input": "/io/in/A/4/col",
+        "output": "/headamp/a/4/config_color"
+    },
+    {
+        "input": "/io/in/A/4/g",
+        "output": "/headamp/a/4/gain"
+    },
+    {
+        "input": "/io/in/A/4/name",
+        "output": "/headamp/a/4/config_name"
+    },
+    {
+        "input": "/io/in/A/4/vph",
+        "output": "/headamp/a/4/phantom"
+    },
+    {
+        "input": "/io/in/A/40/col",
+        "output": "/headamp/a/40/config_color"
+    },
+    {
+        "input": "/io/in/A/40/g",
+        "output": "/headamp/a/40/gain"
+    },
+    {
+        "input": "/io/in/A/40/name",
+        "output": "/headamp/a/40/config_name"
+    },
+    {
+        "input": "/io/in/A/40/vph",
+        "output": "/headamp/a/40/phantom"
+    },
+    {
+        "input": "/io/in/A/41/col",
+        "output": "/headamp/a/41/config_color"
+    },
+    {
+        "input": "/io/in/A/41/g",
+        "output": "/headamp/a/41/gain"
+    },
+    {
+        "input": "/io/in/A/41/name",
+        "output": "/headamp/a/41/config_name"
+    },
+    {
+        "input": "/io/in/A/41/vph",
+        "output": "/headamp/a/41/phantom"
+    },
+    {
+        "input": "/io/in/A/42/col",
+        "output": "/headamp/a/42/config_color"
+    },
+    {
+        "input": "/io/in/A/42/g",
+        "output": "/headamp/a/42/gain"
+    },
+    {
+        "input": "/io/in/A/42/name",
+        "output": "/headamp/a/42/config_name"
+    },
+    {
+        "input": "/io/in/A/42/vph",
+        "output": "/headamp/a/42/phantom"
+    },
+    {
+        "input": "/io/in/A/43/col",
+        "output": "/headamp/a/43/config_color"
+    },
+    {
+        "input": "/io/in/A/43/g",
+        "output": "/headamp/a/43/gain"
+    },
+    {
+        "input": "/io/in/A/43/name",
+        "output": "/headamp/a/43/config_name"
+    },
+    {
+        "input": "/io/in/A/43/vph",
+        "output": "/headamp/a/43/phantom"
+    },
+    {
+        "input": "/io/in/A/44/col",
+        "output": "/headamp/a/44/config_color"
+    },
+    {
+        "input": "/io/in/A/44/g",
+        "output": "/headamp/a/44/gain"
+    },
+    {
+        "input": "/io/in/A/44/name",
+        "output": "/headamp/a/44/config_name"
+    },
+    {
+        "input": "/io/in/A/44/vph",
+        "output": "/headamp/a/44/phantom"
+    },
+    {
+        "input": "/io/in/A/45/col",
+        "output": "/headamp/a/45/config_color"
+    },
+    {
+        "input": "/io/in/A/45/g",
+        "output": "/headamp/a/45/gain"
+    },
+    {
+        "input": "/io/in/A/45/name",
+        "output": "/headamp/a/45/config_name"
+    },
+    {
+        "input": "/io/in/A/45/vph",
+        "output": "/headamp/a/45/phantom"
+    },
+    {
+        "input": "/io/in/A/46/col",
+        "output": "/headamp/a/46/config_color"
+    },
+    {
+        "input": "/io/in/A/46/g",
+        "output": "/headamp/a/46/gain"
+    },
+    {
+        "input": "/io/in/A/46/name",
+        "output": "/headamp/a/46/config_name"
+    },
+    {
+        "input": "/io/in/A/46/vph",
+        "output": "/headamp/a/46/phantom"
+    },
+    {
+        "input": "/io/in/A/47/col",
+        "output": "/headamp/a/47/config_color"
+    },
+    {
+        "input": "/io/in/A/47/g",
+        "output": "/headamp/a/47/gain"
+    },
+    {
+        "input": "/io/in/A/47/name",
+        "output": "/headamp/a/47/config_name"
+    },
+    {
+        "input": "/io/in/A/47/vph",
+        "output": "/headamp/a/47/phantom"
+    },
+    {
+        "input": "/io/in/A/48/col",
+        "output": "/headamp/a/48/config_color"
+    },
+    {
+        "input": "/io/in/A/48/g",
+        "output": "/headamp/a/48/gain"
+    },
+    {
+        "input": "/io/in/A/48/name",
+        "output": "/headamp/a/48/config_name"
+    },
+    {
+        "input": "/io/in/A/48/vph",
+        "output": "/headamp/a/48/phantom"
+    },
+    {
+        "input": "/io/in/A/5/col",
+        "output": "/headamp/a/5/config_color"
+    },
+    {
+        "input": "/io/in/A/5/g",
+        "output": "/headamp/a/5/gain"
+    },
+    {
+        "input": "/io/in/A/5/name",
+        "output": "/headamp/a/5/config_name"
+    },
+    {
+        "input": "/io/in/A/5/vph",
+        "output": "/headamp/a/5/phantom"
+    },
+    {
+        "input": "/io/in/A/6/col",
+        "output": "/headamp/a/6/config_color"
+    },
+    {
+        "input": "/io/in/A/6/g",
+        "output": "/headamp/a/6/gain"
+    },
+    {
+        "input": "/io/in/A/6/name",
+        "output": "/headamp/a/6/config_name"
+    },
+    {
+        "input": "/io/in/A/6/vph",
+        "output": "/headamp/a/6/phantom"
+    },
+    {
+        "input": "/io/in/A/7/col",
+        "output": "/headamp/a/7/config_color"
+    },
+    {
+        "input": "/io/in/A/7/g",
+        "output": "/headamp/a/7/gain"
+    },
+    {
+        "input": "/io/in/A/7/name",
+        "output": "/headamp/a/7/config_name"
+    },
+    {
+        "input": "/io/in/A/7/vph",
+        "output": "/headamp/a/7/phantom"
+    },
+    {
+        "input": "/io/in/A/8/col",
+        "output": "/headamp/a/8/config_color"
+    },
+    {
+        "input": "/io/in/A/8/g",
+        "output": "/headamp/a/8/gain"
+    },
+    {
+        "input": "/io/in/A/8/name",
+        "output": "/headamp/a/8/config_name"
+    },
+    {
+        "input": "/io/in/A/8/vph",
+        "output": "/headamp/a/8/phantom"
+    },
+    {
+        "input": "/io/in/A/9/col",
+        "output": "/headamp/a/9/config_color"
+    },
+    {
+        "input": "/io/in/A/9/g",
+        "output": "/headamp/a/9/gain"
+    },
+    {
+        "input": "/io/in/A/9/name",
+        "output": "/headamp/a/9/config_name"
+    },
+    {
+        "input": "/io/in/A/9/vph",
+        "output": "/headamp/a/9/phantom"
+    },
+    {
+        "input": "/io/in/B/1/col",
+        "output": "/headamp/b/1/config_color"
+    },
+    {
+        "input": "/io/in/B/1/g",
+        "output": "/headamp/b/1/gain"
+    },
+    {
+        "input": "/io/in/B/1/name",
+        "output": "/headamp/b/1/config_name"
+    },
+    {
+        "input": "/io/in/B/1/vph",
+        "output": "/headamp/b/1/phantom"
+    },
+    {
+        "input": "/io/in/B/10/col",
+        "output": "/headamp/b/10/config_color"
+    },
+    {
+        "input": "/io/in/B/10/g",
+        "output": "/headamp/b/10/gain"
+    },
+    {
+        "input": "/io/in/B/10/name",
+        "output": "/headamp/b/10/config_name"
+    },
+    {
+        "input": "/io/in/B/10/vph",
+        "output": "/headamp/b/10/phantom"
+    },
+    {
+        "input": "/io/in/B/11/col",
+        "output": "/headamp/b/11/config_color"
+    },
+    {
+        "input": "/io/in/B/11/g",
+        "output": "/headamp/b/11/gain"
+    },
+    {
+        "input": "/io/in/B/11/name",
+        "output": "/headamp/b/11/config_name"
+    },
+    {
+        "input": "/io/in/B/11/vph",
+        "output": "/headamp/b/11/phantom"
+    },
+    {
+        "input": "/io/in/B/12/col",
+        "output": "/headamp/b/12/config_color"
+    },
+    {
+        "input": "/io/in/B/12/g",
+        "output": "/headamp/b/12/gain"
+    },
+    {
+        "input": "/io/in/B/12/name",
+        "output": "/headamp/b/12/config_name"
+    },
+    {
+        "input": "/io/in/B/12/vph",
+        "output": "/headamp/b/12/phantom"
+    },
+    {
+        "input": "/io/in/B/13/col",
+        "output": "/headamp/b/13/config_color"
+    },
+    {
+        "input": "/io/in/B/13/g",
+        "output": "/headamp/b/13/gain"
+    },
+    {
+        "input": "/io/in/B/13/name",
+        "output": "/headamp/b/13/config_name"
+    },
+    {
+        "input": "/io/in/B/13/vph",
+        "output": "/headamp/b/13/phantom"
+    },
+    {
+        "input": "/io/in/B/14/col",
+        "output": "/headamp/b/14/config_color"
+    },
+    {
+        "input": "/io/in/B/14/g",
+        "output": "/headamp/b/14/gain"
+    },
+    {
+        "input": "/io/in/B/14/name",
+        "output": "/headamp/b/14/config_name"
+    },
+    {
+        "input": "/io/in/B/14/vph",
+        "output": "/headamp/b/14/phantom"
+    },
+    {
+        "input": "/io/in/B/15/col",
+        "output": "/headamp/b/15/config_color"
+    },
+    {
+        "input": "/io/in/B/15/g",
+        "output": "/headamp/b/15/gain"
+    },
+    {
+        "input": "/io/in/B/15/name",
+        "output": "/headamp/b/15/config_name"
+    },
+    {
+        "input": "/io/in/B/15/vph",
+        "output": "/headamp/b/15/phantom"
+    },
+    {
+        "input": "/io/in/B/16/col",
+        "output": "/headamp/b/16/config_color"
+    },
+    {
+        "input": "/io/in/B/16/g",
+        "output": "/headamp/b/16/gain"
+    },
+    {
+        "input": "/io/in/B/16/name",
+        "output": "/headamp/b/16/config_name"
+    },
+    {
+        "input": "/io/in/B/16/vph",
+        "output": "/headamp/b/16/phantom"
+    },
+    {
+        "input": "/io/in/B/17/col",
+        "output": "/headamp/b/17/config_color"
+    },
+    {
+        "input": "/io/in/B/17/g",
+        "output": "/headamp/b/17/gain"
+    },
+    {
+        "input": "/io/in/B/17/name",
+        "output": "/headamp/b/17/config_name"
+    },
+    {
+        "input": "/io/in/B/17/vph",
+        "output": "/headamp/b/17/phantom"
+    },
+    {
+        "input": "/io/in/B/18/col",
+        "output": "/headamp/b/18/config_color"
+    },
+    {
+        "input": "/io/in/B/18/g",
+        "output": "/headamp/b/18/gain"
+    },
+    {
+        "input": "/io/in/B/18/name",
+        "output": "/headamp/b/18/config_name"
+    },
+    {
+        "input": "/io/in/B/18/vph",
+        "output": "/headamp/b/18/phantom"
+    },
+    {
+        "input": "/io/in/B/19/col",
+        "output": "/headamp/b/19/config_color"
+    },
+    {
+        "input": "/io/in/B/19/g",
+        "output": "/headamp/b/19/gain"
+    },
+    {
+        "input": "/io/in/B/19/name",
+        "output": "/headamp/b/19/config_name"
+    },
+    {
+        "input": "/io/in/B/19/vph",
+        "output": "/headamp/b/19/phantom"
+    },
+    {
+        "input": "/io/in/B/2/col",
+        "output": "/headamp/b/2/config_color"
+    },
+    {
+        "input": "/io/in/B/2/g",
+        "output": "/headamp/b/2/gain"
+    },
+    {
+        "input": "/io/in/B/2/name",
+        "output": "/headamp/b/2/config_name"
+    },
+    {
+        "input": "/io/in/B/2/vph",
+        "output": "/headamp/b/2/phantom"
+    },
+    {
+        "input": "/io/in/B/20/col",
+        "output": "/headamp/b/20/config_color"
+    },
+    {
+        "input": "/io/in/B/20/g",
+        "output": "/headamp/b/20/gain"
+    },
+    {
+        "input": "/io/in/B/20/name",
+        "output": "/headamp/b/20/config_name"
+    },
+    {
+        "input": "/io/in/B/20/vph",
+        "output": "/headamp/b/20/phantom"
+    },
+    {
+        "input": "/io/in/B/21/col",
+        "output": "/headamp/b/21/config_color"
+    },
+    {
+        "input": "/io/in/B/21/g",
+        "output": "/headamp/b/21/gain"
+    },
+    {
+        "input": "/io/in/B/21/name",
+        "output": "/headamp/b/21/config_name"
+    },
+    {
+        "input": "/io/in/B/21/vph",
+        "output": "/headamp/b/21/phantom"
+    },
+    {
+        "input": "/io/in/B/22/col",
+        "output": "/headamp/b/22/config_color"
+    },
+    {
+        "input": "/io/in/B/22/g",
+        "output": "/headamp/b/22/gain"
+    },
+    {
+        "input": "/io/in/B/22/name",
+        "output": "/headamp/b/22/config_name"
+    },
+    {
+        "input": "/io/in/B/22/vph",
+        "output": "/headamp/b/22/phantom"
+    },
+    {
+        "input": "/io/in/B/23/col",
+        "output": "/headamp/b/23/config_color"
+    },
+    {
+        "input": "/io/in/B/23/g",
+        "output": "/headamp/b/23/gain"
+    },
+    {
+        "input": "/io/in/B/23/name",
+        "output": "/headamp/b/23/config_name"
+    },
+    {
+        "input": "/io/in/B/23/vph",
+        "output": "/headamp/b/23/phantom"
+    },
+    {
+        "input": "/io/in/B/24/col",
+        "output": "/headamp/b/24/config_color"
+    },
+    {
+        "input": "/io/in/B/24/g",
+        "output": "/headamp/b/24/gain"
+    },
+    {
+        "input": "/io/in/B/24/name",
+        "output": "/headamp/b/24/config_name"
+    },
+    {
+        "input": "/io/in/B/24/vph",
+        "output": "/headamp/b/24/phantom"
+    },
+    {
+        "input": "/io/in/B/25/col",
+        "output": "/headamp/b/25/config_color"
+    },
+    {
+        "input": "/io/in/B/25/g",
+        "output": "/headamp/b/25/gain"
+    },
+    {
+        "input": "/io/in/B/25/name",
+        "output": "/headamp/b/25/config_name"
+    },
+    {
+        "input": "/io/in/B/25/vph",
+        "output": "/headamp/b/25/phantom"
+    },
+    {
+        "input": "/io/in/B/26/col",
+        "output": "/headamp/b/26/config_color"
+    },
+    {
+        "input": "/io/in/B/26/g",
+        "output": "/headamp/b/26/gain"
+    },
+    {
+        "input": "/io/in/B/26/name",
+        "output": "/headamp/b/26/config_name"
+    },
+    {
+        "input": "/io/in/B/26/vph",
+        "output": "/headamp/b/26/phantom"
+    },
+    {
+        "input": "/io/in/B/27/col",
+        "output": "/headamp/b/27/config_color"
+    },
+    {
+        "input": "/io/in/B/27/g",
+        "output": "/headamp/b/27/gain"
+    },
+    {
+        "input": "/io/in/B/27/name",
+        "output": "/headamp/b/27/config_name"
+    },
+    {
+        "input": "/io/in/B/27/vph",
+        "output": "/headamp/b/27/phantom"
+    },
+    {
+        "input": "/io/in/B/28/col",
+        "output": "/headamp/b/28/config_color"
+    },
+    {
+        "input": "/io/in/B/28/g",
+        "output": "/headamp/b/28/gain"
+    },
+    {
+        "input": "/io/in/B/28/name",
+        "output": "/headamp/b/28/config_name"
+    },
+    {
+        "input": "/io/in/B/28/vph",
+        "output": "/headamp/b/28/phantom"
+    },
+    {
+        "input": "/io/in/B/29/col",
+        "output": "/headamp/b/29/config_color"
+    },
+    {
+        "input": "/io/in/B/29/g",
+        "output": "/headamp/b/29/gain"
+    },
+    {
+        "input": "/io/in/B/29/name",
+        "output": "/headamp/b/29/config_name"
+    },
+    {
+        "input": "/io/in/B/29/vph",
+        "output": "/headamp/b/29/phantom"
+    },
+    {
+        "input": "/io/in/B/3/col",
+        "output": "/headamp/b/3/config_color"
+    },
+    {
+        "input": "/io/in/B/3/g",
+        "output": "/headamp/b/3/gain"
+    },
+    {
+        "input": "/io/in/B/3/name",
+        "output": "/headamp/b/3/config_name"
+    },
+    {
+        "input": "/io/in/B/3/vph",
+        "output": "/headamp/b/3/phantom"
+    },
+    {
+        "input": "/io/in/B/30/col",
+        "output": "/headamp/b/30/config_color"
+    },
+    {
+        "input": "/io/in/B/30/g",
+        "output": "/headamp/b/30/gain"
+    },
+    {
+        "input": "/io/in/B/30/name",
+        "output": "/headamp/b/30/config_name"
+    },
+    {
+        "input": "/io/in/B/30/vph",
+        "output": "/headamp/b/30/phantom"
+    },
+    {
+        "input": "/io/in/B/31/col",
+        "output": "/headamp/b/31/config_color"
+    },
+    {
+        "input": "/io/in/B/31/g",
+        "output": "/headamp/b/31/gain"
+    },
+    {
+        "input": "/io/in/B/31/name",
+        "output": "/headamp/b/31/config_name"
+    },
+    {
+        "input": "/io/in/B/31/vph",
+        "output": "/headamp/b/31/phantom"
+    },
+    {
+        "input": "/io/in/B/32/col",
+        "output": "/headamp/b/32/config_color"
+    },
+    {
+        "input": "/io/in/B/32/g",
+        "output": "/headamp/b/32/gain"
+    },
+    {
+        "input": "/io/in/B/32/name",
+        "output": "/headamp/b/32/config_name"
+    },
+    {
+        "input": "/io/in/B/32/vph",
+        "output": "/headamp/b/32/phantom"
+    },
+    {
+        "input": "/io/in/B/33/col",
+        "output": "/headamp/b/33/config_color"
+    },
+    {
+        "input": "/io/in/B/33/g",
+        "output": "/headamp/b/33/gain"
+    },
+    {
+        "input": "/io/in/B/33/name",
+        "output": "/headamp/b/33/config_name"
+    },
+    {
+        "input": "/io/in/B/33/vph",
+        "output": "/headamp/b/33/phantom"
+    },
+    {
+        "input": "/io/in/B/34/col",
+        "output": "/headamp/b/34/config_color"
+    },
+    {
+        "input": "/io/in/B/34/g",
+        "output": "/headamp/b/34/gain"
+    },
+    {
+        "input": "/io/in/B/34/name",
+        "output": "/headamp/b/34/config_name"
+    },
+    {
+        "input": "/io/in/B/34/vph",
+        "output": "/headamp/b/34/phantom"
+    },
+    {
+        "input": "/io/in/B/35/col",
+        "output": "/headamp/b/35/config_color"
+    },
+    {
+        "input": "/io/in/B/35/g",
+        "output": "/headamp/b/35/gain"
+    },
+    {
+        "input": "/io/in/B/35/name",
+        "output": "/headamp/b/35/config_name"
+    },
+    {
+        "input": "/io/in/B/35/vph",
+        "output": "/headamp/b/35/phantom"
+    },
+    {
+        "input": "/io/in/B/36/col",
+        "output": "/headamp/b/36/config_color"
+    },
+    {
+        "input": "/io/in/B/36/g",
+        "output": "/headamp/b/36/gain"
+    },
+    {
+        "input": "/io/in/B/36/name",
+        "output": "/headamp/b/36/config_name"
+    },
+    {
+        "input": "/io/in/B/36/vph",
+        "output": "/headamp/b/36/phantom"
+    },
+    {
+        "input": "/io/in/B/37/col",
+        "output": "/headamp/b/37/config_color"
+    },
+    {
+        "input": "/io/in/B/37/g",
+        "output": "/headamp/b/37/gain"
+    },
+    {
+        "input": "/io/in/B/37/name",
+        "output": "/headamp/b/37/config_name"
+    },
+    {
+        "input": "/io/in/B/37/vph",
+        "output": "/headamp/b/37/phantom"
+    },
+    {
+        "input": "/io/in/B/38/col",
+        "output": "/headamp/b/38/config_color"
+    },
+    {
+        "input": "/io/in/B/38/g",
+        "output": "/headamp/b/38/gain"
+    },
+    {
+        "input": "/io/in/B/38/name",
+        "output": "/headamp/b/38/config_name"
+    },
+    {
+        "input": "/io/in/B/38/vph",
+        "output": "/headamp/b/38/phantom"
+    },
+    {
+        "input": "/io/in/B/39/col",
+        "output": "/headamp/b/39/config_color"
+    },
+    {
+        "input": "/io/in/B/39/g",
+        "output": "/headamp/b/39/gain"
+    },
+    {
+        "input": "/io/in/B/39/name",
+        "output": "/headamp/b/39/config_name"
+    },
+    {
+        "input": "/io/in/B/39/vph",
+        "output": "/headamp/b/39/phantom"
+    },
+    {
+        "input": "/io/in/B/4/col",
+        "output": "/headamp/b/4/config_color"
+    },
+    {
+        "input": "/io/in/B/4/g",
+        "output": "/headamp/b/4/gain"
+    },
+    {
+        "input": "/io/in/B/4/name",
+        "output": "/headamp/b/4/config_name"
+    },
+    {
+        "input": "/io/in/B/4/vph",
+        "output": "/headamp/b/4/phantom"
+    },
+    {
+        "input": "/io/in/B/40/col",
+        "output": "/headamp/b/40/config_color"
+    },
+    {
+        "input": "/io/in/B/40/g",
+        "output": "/headamp/b/40/gain"
+    },
+    {
+        "input": "/io/in/B/40/name",
+        "output": "/headamp/b/40/config_name"
+    },
+    {
+        "input": "/io/in/B/40/vph",
+        "output": "/headamp/b/40/phantom"
+    },
+    {
+        "input": "/io/in/B/41/col",
+        "output": "/headamp/b/41/config_color"
+    },
+    {
+        "input": "/io/in/B/41/g",
+        "output": "/headamp/b/41/gain"
+    },
+    {
+        "input": "/io/in/B/41/name",
+        "output": "/headamp/b/41/config_name"
+    },
+    {
+        "input": "/io/in/B/41/vph",
+        "output": "/headamp/b/41/phantom"
+    },
+    {
+        "input": "/io/in/B/42/col",
+        "output": "/headamp/b/42/config_color"
+    },
+    {
+        "input": "/io/in/B/42/g",
+        "output": "/headamp/b/42/gain"
+    },
+    {
+        "input": "/io/in/B/42/name",
+        "output": "/headamp/b/42/config_name"
+    },
+    {
+        "input": "/io/in/B/42/vph",
+        "output": "/headamp/b/42/phantom"
+    },
+    {
+        "input": "/io/in/B/43/col",
+        "output": "/headamp/b/43/config_color"
+    },
+    {
+        "input": "/io/in/B/43/g",
+        "output": "/headamp/b/43/gain"
+    },
+    {
+        "input": "/io/in/B/43/name",
+        "output": "/headamp/b/43/config_name"
+    },
+    {
+        "input": "/io/in/B/43/vph",
+        "output": "/headamp/b/43/phantom"
+    },
+    {
+        "input": "/io/in/B/44/col",
+        "output": "/headamp/b/44/config_color"
+    },
+    {
+        "input": "/io/in/B/44/g",
+        "output": "/headamp/b/44/gain"
+    },
+    {
+        "input": "/io/in/B/44/name",
+        "output": "/headamp/b/44/config_name"
+    },
+    {
+        "input": "/io/in/B/44/vph",
+        "output": "/headamp/b/44/phantom"
+    },
+    {
+        "input": "/io/in/B/45/col",
+        "output": "/headamp/b/45/config_color"
+    },
+    {
+        "input": "/io/in/B/45/g",
+        "output": "/headamp/b/45/gain"
+    },
+    {
+        "input": "/io/in/B/45/name",
+        "output": "/headamp/b/45/config_name"
+    },
+    {
+        "input": "/io/in/B/45/vph",
+        "output": "/headamp/b/45/phantom"
+    },
+    {
+        "input": "/io/in/B/46/col",
+        "output": "/headamp/b/46/config_color"
+    },
+    {
+        "input": "/io/in/B/46/g",
+        "output": "/headamp/b/46/gain"
+    },
+    {
+        "input": "/io/in/B/46/name",
+        "output": "/headamp/b/46/config_name"
+    },
+    {
+        "input": "/io/in/B/46/vph",
+        "output": "/headamp/b/46/phantom"
+    },
+    {
+        "input": "/io/in/B/47/col",
+        "output": "/headamp/b/47/config_color"
+    },
+    {
+        "input": "/io/in/B/47/g",
+        "output": "/headamp/b/47/gain"
+    },
+    {
+        "input": "/io/in/B/47/name",
+        "output": "/headamp/b/47/config_name"
+    },
+    {
+        "input": "/io/in/B/47/vph",
+        "output": "/headamp/b/47/phantom"
+    },
+    {
+        "input": "/io/in/B/48/col",
+        "output": "/headamp/b/48/config_color"
+    },
+    {
+        "input": "/io/in/B/48/g",
+        "output": "/headamp/b/48/gain"
+    },
+    {
+        "input": "/io/in/B/48/name",
+        "output": "/headamp/b/48/config_name"
+    },
+    {
+        "input": "/io/in/B/48/vph",
+        "output": "/headamp/b/48/phantom"
+    },
+    {
+        "input": "/io/in/B/5/col",
+        "output": "/headamp/b/5/config_color"
+    },
+    {
+        "input": "/io/in/B/5/g",
+        "output": "/headamp/b/5/gain"
+    },
+    {
+        "input": "/io/in/B/5/name",
+        "output": "/headamp/b/5/config_name"
+    },
+    {
+        "input": "/io/in/B/5/vph",
+        "output": "/headamp/b/5/phantom"
+    },
+    {
+        "input": "/io/in/B/6/col",
+        "output": "/headamp/b/6/config_color"
+    },
+    {
+        "input": "/io/in/B/6/g",
+        "output": "/headamp/b/6/gain"
+    },
+    {
+        "input": "/io/in/B/6/name",
+        "output": "/headamp/b/6/config_name"
+    },
+    {
+        "input": "/io/in/B/6/vph",
+        "output": "/headamp/b/6/phantom"
+    },
+    {
+        "input": "/io/in/B/7/col",
+        "output": "/headamp/b/7/config_color"
+    },
+    {
+        "input": "/io/in/B/7/g",
+        "output": "/headamp/b/7/gain"
+    },
+    {
+        "input": "/io/in/B/7/name",
+        "output": "/headamp/b/7/config_name"
+    },
+    {
+        "input": "/io/in/B/7/vph",
+        "output": "/headamp/b/7/phantom"
+    },
+    {
+        "input": "/io/in/B/8/col",
+        "output": "/headamp/b/8/config_color"
+    },
+    {
+        "input": "/io/in/B/8/g",
+        "output": "/headamp/b/8/gain"
+    },
+    {
+        "input": "/io/in/B/8/name",
+        "output": "/headamp/b/8/config_name"
+    },
+    {
+        "input": "/io/in/B/8/vph",
+        "output": "/headamp/b/8/phantom"
+    },
+    {
+        "input": "/io/in/B/9/col",
+        "output": "/headamp/b/9/config_color"
+    },
+    {
+        "input": "/io/in/B/9/g",
+        "output": "/headamp/b/9/gain"
+    },
+    {
+        "input": "/io/in/B/9/name",
+        "output": "/headamp/b/9/config_name"
+    },
+    {
+        "input": "/io/in/B/9/vph",
+        "output": "/headamp/b/9/phantom"
+    },
+    {
+        "input": "/io/in/C/1/col",
+        "output": "/headamp/c/1/config_color"
+    },
+    {
+        "input": "/io/in/C/1/g",
+        "output": "/headamp/c/1/gain"
+    },
+    {
+        "input": "/io/in/C/1/name",
+        "output": "/headamp/c/1/config_name"
+    },
+    {
+        "input": "/io/in/C/1/vph",
+        "output": "/headamp/c/1/phantom"
+    },
+    {
+        "input": "/io/in/C/10/col",
+        "output": "/headamp/c/10/config_color"
+    },
+    {
+        "input": "/io/in/C/10/g",
+        "output": "/headamp/c/10/gain"
+    },
+    {
+        "input": "/io/in/C/10/name",
+        "output": "/headamp/c/10/config_name"
+    },
+    {
+        "input": "/io/in/C/10/vph",
+        "output": "/headamp/c/10/phantom"
+    },
+    {
+        "input": "/io/in/C/11/col",
+        "output": "/headamp/c/11/config_color"
+    },
+    {
+        "input": "/io/in/C/11/g",
+        "output": "/headamp/c/11/gain"
+    },
+    {
+        "input": "/io/in/C/11/name",
+        "output": "/headamp/c/11/config_name"
+    },
+    {
+        "input": "/io/in/C/11/vph",
+        "output": "/headamp/c/11/phantom"
+    },
+    {
+        "input": "/io/in/C/12/col",
+        "output": "/headamp/c/12/config_color"
+    },
+    {
+        "input": "/io/in/C/12/g",
+        "output": "/headamp/c/12/gain"
+    },
+    {
+        "input": "/io/in/C/12/name",
+        "output": "/headamp/c/12/config_name"
+    },
+    {
+        "input": "/io/in/C/12/vph",
+        "output": "/headamp/c/12/phantom"
+    },
+    {
+        "input": "/io/in/C/13/col",
+        "output": "/headamp/c/13/config_color"
+    },
+    {
+        "input": "/io/in/C/13/g",
+        "output": "/headamp/c/13/gain"
+    },
+    {
+        "input": "/io/in/C/13/name",
+        "output": "/headamp/c/13/config_name"
+    },
+    {
+        "input": "/io/in/C/13/vph",
+        "output": "/headamp/c/13/phantom"
+    },
+    {
+        "input": "/io/in/C/14/col",
+        "output": "/headamp/c/14/config_color"
+    },
+    {
+        "input": "/io/in/C/14/g",
+        "output": "/headamp/c/14/gain"
+    },
+    {
+        "input": "/io/in/C/14/name",
+        "output": "/headamp/c/14/config_name"
+    },
+    {
+        "input": "/io/in/C/14/vph",
+        "output": "/headamp/c/14/phantom"
+    },
+    {
+        "input": "/io/in/C/15/col",
+        "output": "/headamp/c/15/config_color"
+    },
+    {
+        "input": "/io/in/C/15/g",
+        "output": "/headamp/c/15/gain"
+    },
+    {
+        "input": "/io/in/C/15/name",
+        "output": "/headamp/c/15/config_name"
+    },
+    {
+        "input": "/io/in/C/15/vph",
+        "output": "/headamp/c/15/phantom"
+    },
+    {
+        "input": "/io/in/C/16/col",
+        "output": "/headamp/c/16/config_color"
+    },
+    {
+        "input": "/io/in/C/16/g",
+        "output": "/headamp/c/16/gain"
+    },
+    {
+        "input": "/io/in/C/16/name",
+        "output": "/headamp/c/16/config_name"
+    },
+    {
+        "input": "/io/in/C/16/vph",
+        "output": "/headamp/c/16/phantom"
+    },
+    {
+        "input": "/io/in/C/17/col",
+        "output": "/headamp/c/17/config_color"
+    },
+    {
+        "input": "/io/in/C/17/g",
+        "output": "/headamp/c/17/gain"
+    },
+    {
+        "input": "/io/in/C/17/name",
+        "output": "/headamp/c/17/config_name"
+    },
+    {
+        "input": "/io/in/C/17/vph",
+        "output": "/headamp/c/17/phantom"
+    },
+    {
+        "input": "/io/in/C/18/col",
+        "output": "/headamp/c/18/config_color"
+    },
+    {
+        "input": "/io/in/C/18/g",
+        "output": "/headamp/c/18/gain"
+    },
+    {
+        "input": "/io/in/C/18/name",
+        "output": "/headamp/c/18/config_name"
+    },
+    {
+        "input": "/io/in/C/18/vph",
+        "output": "/headamp/c/18/phantom"
+    },
+    {
+        "input": "/io/in/C/19/col",
+        "output": "/headamp/c/19/config_color"
+    },
+    {
+        "input": "/io/in/C/19/g",
+        "output": "/headamp/c/19/gain"
+    },
+    {
+        "input": "/io/in/C/19/name",
+        "output": "/headamp/c/19/config_name"
+    },
+    {
+        "input": "/io/in/C/19/vph",
+        "output": "/headamp/c/19/phantom"
+    },
+    {
+        "input": "/io/in/C/2/col",
+        "output": "/headamp/c/2/config_color"
+    },
+    {
+        "input": "/io/in/C/2/g",
+        "output": "/headamp/c/2/gain"
+    },
+    {
+        "input": "/io/in/C/2/name",
+        "output": "/headamp/c/2/config_name"
+    },
+    {
+        "input": "/io/in/C/2/vph",
+        "output": "/headamp/c/2/phantom"
+    },
+    {
+        "input": "/io/in/C/20/col",
+        "output": "/headamp/c/20/config_color"
+    },
+    {
+        "input": "/io/in/C/20/g",
+        "output": "/headamp/c/20/gain"
+    },
+    {
+        "input": "/io/in/C/20/name",
+        "output": "/headamp/c/20/config_name"
+    },
+    {
+        "input": "/io/in/C/20/vph",
+        "output": "/headamp/c/20/phantom"
+    },
+    {
+        "input": "/io/in/C/21/col",
+        "output": "/headamp/c/21/config_color"
+    },
+    {
+        "input": "/io/in/C/21/g",
+        "output": "/headamp/c/21/gain"
+    },
+    {
+        "input": "/io/in/C/21/name",
+        "output": "/headamp/c/21/config_name"
+    },
+    {
+        "input": "/io/in/C/21/vph",
+        "output": "/headamp/c/21/phantom"
+    },
+    {
+        "input": "/io/in/C/22/col",
+        "output": "/headamp/c/22/config_color"
+    },
+    {
+        "input": "/io/in/C/22/g",
+        "output": "/headamp/c/22/gain"
+    },
+    {
+        "input": "/io/in/C/22/name",
+        "output": "/headamp/c/22/config_name"
+    },
+    {
+        "input": "/io/in/C/22/vph",
+        "output": "/headamp/c/22/phantom"
+    },
+    {
+        "input": "/io/in/C/23/col",
+        "output": "/headamp/c/23/config_color"
+    },
+    {
+        "input": "/io/in/C/23/g",
+        "output": "/headamp/c/23/gain"
+    },
+    {
+        "input": "/io/in/C/23/name",
+        "output": "/headamp/c/23/config_name"
+    },
+    {
+        "input": "/io/in/C/23/vph",
+        "output": "/headamp/c/23/phantom"
+    },
+    {
+        "input": "/io/in/C/24/col",
+        "output": "/headamp/c/24/config_color"
+    },
+    {
+        "input": "/io/in/C/24/g",
+        "output": "/headamp/c/24/gain"
+    },
+    {
+        "input": "/io/in/C/24/name",
+        "output": "/headamp/c/24/config_name"
+    },
+    {
+        "input": "/io/in/C/24/vph",
+        "output": "/headamp/c/24/phantom"
+    },
+    {
+        "input": "/io/in/C/25/col",
+        "output": "/headamp/c/25/config_color"
+    },
+    {
+        "input": "/io/in/C/25/g",
+        "output": "/headamp/c/25/gain"
+    },
+    {
+        "input": "/io/in/C/25/name",
+        "output": "/headamp/c/25/config_name"
+    },
+    {
+        "input": "/io/in/C/25/vph",
+        "output": "/headamp/c/25/phantom"
+    },
+    {
+        "input": "/io/in/C/26/col",
+        "output": "/headamp/c/26/config_color"
+    },
+    {
+        "input": "/io/in/C/26/g",
+        "output": "/headamp/c/26/gain"
+    },
+    {
+        "input": "/io/in/C/26/name",
+        "output": "/headamp/c/26/config_name"
+    },
+    {
+        "input": "/io/in/C/26/vph",
+        "output": "/headamp/c/26/phantom"
+    },
+    {
+        "input": "/io/in/C/27/col",
+        "output": "/headamp/c/27/config_color"
+    },
+    {
+        "input": "/io/in/C/27/g",
+        "output": "/headamp/c/27/gain"
+    },
+    {
+        "input": "/io/in/C/27/name",
+        "output": "/headamp/c/27/config_name"
+    },
+    {
+        "input": "/io/in/C/27/vph",
+        "output": "/headamp/c/27/phantom"
+    },
+    {
+        "input": "/io/in/C/28/col",
+        "output": "/headamp/c/28/config_color"
+    },
+    {
+        "input": "/io/in/C/28/g",
+        "output": "/headamp/c/28/gain"
+    },
+    {
+        "input": "/io/in/C/28/name",
+        "output": "/headamp/c/28/config_name"
+    },
+    {
+        "input": "/io/in/C/28/vph",
+        "output": "/headamp/c/28/phantom"
+    },
+    {
+        "input": "/io/in/C/29/col",
+        "output": "/headamp/c/29/config_color"
+    },
+    {
+        "input": "/io/in/C/29/g",
+        "output": "/headamp/c/29/gain"
+    },
+    {
+        "input": "/io/in/C/29/name",
+        "output": "/headamp/c/29/config_name"
+    },
+    {
+        "input": "/io/in/C/29/vph",
+        "output": "/headamp/c/29/phantom"
+    },
+    {
+        "input": "/io/in/C/3/col",
+        "output": "/headamp/c/3/config_color"
+    },
+    {
+        "input": "/io/in/C/3/g",
+        "output": "/headamp/c/3/gain"
+    },
+    {
+        "input": "/io/in/C/3/name",
+        "output": "/headamp/c/3/config_name"
+    },
+    {
+        "input": "/io/in/C/3/vph",
+        "output": "/headamp/c/3/phantom"
+    },
+    {
+        "input": "/io/in/C/30/col",
+        "output": "/headamp/c/30/config_color"
+    },
+    {
+        "input": "/io/in/C/30/g",
+        "output": "/headamp/c/30/gain"
+    },
+    {
+        "input": "/io/in/C/30/name",
+        "output": "/headamp/c/30/config_name"
+    },
+    {
+        "input": "/io/in/C/30/vph",
+        "output": "/headamp/c/30/phantom"
+    },
+    {
+        "input": "/io/in/C/31/col",
+        "output": "/headamp/c/31/config_color"
+    },
+    {
+        "input": "/io/in/C/31/g",
+        "output": "/headamp/c/31/gain"
+    },
+    {
+        "input": "/io/in/C/31/name",
+        "output": "/headamp/c/31/config_name"
+    },
+    {
+        "input": "/io/in/C/31/vph",
+        "output": "/headamp/c/31/phantom"
+    },
+    {
+        "input": "/io/in/C/32/col",
+        "output": "/headamp/c/32/config_color"
+    },
+    {
+        "input": "/io/in/C/32/g",
+        "output": "/headamp/c/32/gain"
+    },
+    {
+        "input": "/io/in/C/32/name",
+        "output": "/headamp/c/32/config_name"
+    },
+    {
+        "input": "/io/in/C/32/vph",
+        "output": "/headamp/c/32/phantom"
+    },
+    {
+        "input": "/io/in/C/33/col",
+        "output": "/headamp/c/33/config_color"
+    },
+    {
+        "input": "/io/in/C/33/g",
+        "output": "/headamp/c/33/gain"
+    },
+    {
+        "input": "/io/in/C/33/name",
+        "output": "/headamp/c/33/config_name"
+    },
+    {
+        "input": "/io/in/C/33/vph",
+        "output": "/headamp/c/33/phantom"
+    },
+    {
+        "input": "/io/in/C/34/col",
+        "output": "/headamp/c/34/config_color"
+    },
+    {
+        "input": "/io/in/C/34/g",
+        "output": "/headamp/c/34/gain"
+    },
+    {
+        "input": "/io/in/C/34/name",
+        "output": "/headamp/c/34/config_name"
+    },
+    {
+        "input": "/io/in/C/34/vph",
+        "output": "/headamp/c/34/phantom"
+    },
+    {
+        "input": "/io/in/C/35/col",
+        "output": "/headamp/c/35/config_color"
+    },
+    {
+        "input": "/io/in/C/35/g",
+        "output": "/headamp/c/35/gain"
+    },
+    {
+        "input": "/io/in/C/35/name",
+        "output": "/headamp/c/35/config_name"
+    },
+    {
+        "input": "/io/in/C/35/vph",
+        "output": "/headamp/c/35/phantom"
+    },
+    {
+        "input": "/io/in/C/36/col",
+        "output": "/headamp/c/36/config_color"
+    },
+    {
+        "input": "/io/in/C/36/g",
+        "output": "/headamp/c/36/gain"
+    },
+    {
+        "input": "/io/in/C/36/name",
+        "output": "/headamp/c/36/config_name"
+    },
+    {
+        "input": "/io/in/C/36/vph",
+        "output": "/headamp/c/36/phantom"
+    },
+    {
+        "input": "/io/in/C/37/col",
+        "output": "/headamp/c/37/config_color"
+    },
+    {
+        "input": "/io/in/C/37/g",
+        "output": "/headamp/c/37/gain"
+    },
+    {
+        "input": "/io/in/C/37/name",
+        "output": "/headamp/c/37/config_name"
+    },
+    {
+        "input": "/io/in/C/37/vph",
+        "output": "/headamp/c/37/phantom"
+    },
+    {
+        "input": "/io/in/C/38/col",
+        "output": "/headamp/c/38/config_color"
+    },
+    {
+        "input": "/io/in/C/38/g",
+        "output": "/headamp/c/38/gain"
+    },
+    {
+        "input": "/io/in/C/38/name",
+        "output": "/headamp/c/38/config_name"
+    },
+    {
+        "input": "/io/in/C/38/vph",
+        "output": "/headamp/c/38/phantom"
+    },
+    {
+        "input": "/io/in/C/39/col",
+        "output": "/headamp/c/39/config_color"
+    },
+    {
+        "input": "/io/in/C/39/g",
+        "output": "/headamp/c/39/gain"
+    },
+    {
+        "input": "/io/in/C/39/name",
+        "output": "/headamp/c/39/config_name"
+    },
+    {
+        "input": "/io/in/C/39/vph",
+        "output": "/headamp/c/39/phantom"
+    },
+    {
+        "input": "/io/in/C/4/col",
+        "output": "/headamp/c/4/config_color"
+    },
+    {
+        "input": "/io/in/C/4/g",
+        "output": "/headamp/c/4/gain"
+    },
+    {
+        "input": "/io/in/C/4/name",
+        "output": "/headamp/c/4/config_name"
+    },
+    {
+        "input": "/io/in/C/4/vph",
+        "output": "/headamp/c/4/phantom"
+    },
+    {
+        "input": "/io/in/C/40/col",
+        "output": "/headamp/c/40/config_color"
+    },
+    {
+        "input": "/io/in/C/40/g",
+        "output": "/headamp/c/40/gain"
+    },
+    {
+        "input": "/io/in/C/40/name",
+        "output": "/headamp/c/40/config_name"
+    },
+    {
+        "input": "/io/in/C/40/vph",
+        "output": "/headamp/c/40/phantom"
+    },
+    {
+        "input": "/io/in/C/41/col",
+        "output": "/headamp/c/41/config_color"
+    },
+    {
+        "input": "/io/in/C/41/g",
+        "output": "/headamp/c/41/gain"
+    },
+    {
+        "input": "/io/in/C/41/name",
+        "output": "/headamp/c/41/config_name"
+    },
+    {
+        "input": "/io/in/C/41/vph",
+        "output": "/headamp/c/41/phantom"
+    },
+    {
+        "input": "/io/in/C/42/col",
+        "output": "/headamp/c/42/config_color"
+    },
+    {
+        "input": "/io/in/C/42/g",
+        "output": "/headamp/c/42/gain"
+    },
+    {
+        "input": "/io/in/C/42/name",
+        "output": "/headamp/c/42/config_name"
+    },
+    {
+        "input": "/io/in/C/42/vph",
+        "output": "/headamp/c/42/phantom"
+    },
+    {
+        "input": "/io/in/C/43/col",
+        "output": "/headamp/c/43/config_color"
+    },
+    {
+        "input": "/io/in/C/43/g",
+        "output": "/headamp/c/43/gain"
+    },
+    {
+        "input": "/io/in/C/43/name",
+        "output": "/headamp/c/43/config_name"
+    },
+    {
+        "input": "/io/in/C/43/vph",
+        "output": "/headamp/c/43/phantom"
+    },
+    {
+        "input": "/io/in/C/44/col",
+        "output": "/headamp/c/44/config_color"
+    },
+    {
+        "input": "/io/in/C/44/g",
+        "output": "/headamp/c/44/gain"
+    },
+    {
+        "input": "/io/in/C/44/name",
+        "output": "/headamp/c/44/config_name"
+    },
+    {
+        "input": "/io/in/C/44/vph",
+        "output": "/headamp/c/44/phantom"
+    },
+    {
+        "input": "/io/in/C/45/col",
+        "output": "/headamp/c/45/config_color"
+    },
+    {
+        "input": "/io/in/C/45/g",
+        "output": "/headamp/c/45/gain"
+    },
+    {
+        "input": "/io/in/C/45/name",
+        "output": "/headamp/c/45/config_name"
+    },
+    {
+        "input": "/io/in/C/45/vph",
+        "output": "/headamp/c/45/phantom"
+    },
+    {
+        "input": "/io/in/C/46/col",
+        "output": "/headamp/c/46/config_color"
+    },
+    {
+        "input": "/io/in/C/46/g",
+        "output": "/headamp/c/46/gain"
+    },
+    {
+        "input": "/io/in/C/46/name",
+        "output": "/headamp/c/46/config_name"
+    },
+    {
+        "input": "/io/in/C/46/vph",
+        "output": "/headamp/c/46/phantom"
+    },
+    {
+        "input": "/io/in/C/47/col",
+        "output": "/headamp/c/47/config_color"
+    },
+    {
+        "input": "/io/in/C/47/g",
+        "output": "/headamp/c/47/gain"
+    },
+    {
+        "input": "/io/in/C/47/name",
+        "output": "/headamp/c/47/config_name"
+    },
+    {
+        "input": "/io/in/C/47/vph",
+        "output": "/headamp/c/47/phantom"
+    },
+    {
+        "input": "/io/in/C/48/col",
+        "output": "/headamp/c/48/config_color"
+    },
+    {
+        "input": "/io/in/C/48/g",
+        "output": "/headamp/c/48/gain"
+    },
+    {
+        "input": "/io/in/C/48/name",
+        "output": "/headamp/c/48/config_name"
+    },
+    {
+        "input": "/io/in/C/48/vph",
+        "output": "/headamp/c/48/phantom"
+    },
+    {
+        "input": "/io/in/C/5/col",
+        "output": "/headamp/c/5/config_color"
+    },
+    {
+        "input": "/io/in/C/5/g",
+        "output": "/headamp/c/5/gain"
+    },
+    {
+        "input": "/io/in/C/5/name",
+        "output": "/headamp/c/5/config_name"
+    },
+    {
+        "input": "/io/in/C/5/vph",
+        "output": "/headamp/c/5/phantom"
+    },
+    {
+        "input": "/io/in/C/6/col",
+        "output": "/headamp/c/6/config_color"
+    },
+    {
+        "input": "/io/in/C/6/g",
+        "output": "/headamp/c/6/gain"
+    },
+    {
+        "input": "/io/in/C/6/name",
+        "output": "/headamp/c/6/config_name"
+    },
+    {
+        "input": "/io/in/C/6/vph",
+        "output": "/headamp/c/6/phantom"
+    },
+    {
+        "input": "/io/in/C/7/col",
+        "output": "/headamp/c/7/config_color"
+    },
+    {
+        "input": "/io/in/C/7/g",
+        "output": "/headamp/c/7/gain"
+    },
+    {
+        "input": "/io/in/C/7/name",
+        "output": "/headamp/c/7/config_name"
+    },
+    {
+        "input": "/io/in/C/7/vph",
+        "output": "/headamp/c/7/phantom"
+    },
+    {
+        "input": "/io/in/C/8/col",
+        "output": "/headamp/c/8/config_color"
+    },
+    {
+        "input": "/io/in/C/8/g",
+        "output": "/headamp/c/8/gain"
+    },
+    {
+        "input": "/io/in/C/8/name",
+        "output": "/headamp/c/8/config_name"
+    },
+    {
+        "input": "/io/in/C/8/vph",
+        "output": "/headamp/c/8/phantom"
+    },
+    {
+        "input": "/io/in/C/9/col",
+        "output": "/headamp/c/9/config_color"
+    },
+    {
+        "input": "/io/in/C/9/g",
+        "output": "/headamp/c/9/gain"
+    },
+    {
+        "input": "/io/in/C/9/name",
+        "output": "/headamp/c/9/config_name"
+    },
+    {
+        "input": "/io/in/C/9/vph",
+        "output": "/headamp/c/9/phantom"
+    },
+    {
+        "input": "/io/in/LCL/1/col",
+        "output": "/headamp/1/config_color"
+    },
+    {
+        "input": "/io/in/LCL/1/g",
+        "output": "/headamp/1/gain"
+    },
+    {
+        "input": "/io/in/LCL/1/name",
+        "output": "/headamp/1/config_name"
+    },
+    {
+        "input": "/io/in/LCL/1/vph",
+        "output": "/headamp/1/phantom"
+    },
+    {
+        "input": "/io/in/LCL/2/col",
+        "output": "/headamp/2/config_color"
+    },
+    {
+        "input": "/io/in/LCL/2/g",
+        "output": "/headamp/2/gain"
+    },
+    {
+        "input": "/io/in/LCL/2/name",
+        "output": "/headamp/2/config_name"
+    },
+    {
+        "input": "/io/in/LCL/2/vph",
+        "output": "/headamp/2/phantom"
+    },
+    {
+        "input": "/io/in/LCL/3/col",
+        "output": "/headamp/3/config_color"
+    },
+    {
+        "input": "/io/in/LCL/3/g",
+        "output": "/headamp/3/gain"
+    },
+    {
+        "input": "/io/in/LCL/3/name",
+        "output": "/headamp/3/config_name"
+    },
+    {
+        "input": "/io/in/LCL/3/vph",
+        "output": "/headamp/3/phantom"
+    },
+    {
+        "input": "/io/in/LCL/4/col",
+        "output": "/headamp/4/config_color"
+    },
+    {
+        "input": "/io/in/LCL/4/g",
+        "output": "/headamp/4/gain"
+    },
+    {
+        "input": "/io/in/LCL/4/name",
+        "output": "/headamp/4/config_name"
+    },
+    {
+        "input": "/io/in/LCL/4/vph",
+        "output": "/headamp/4/phantom"
+    },
+    {
+        "input": "/io/in/LCL/5/col",
+        "output": "/headamp/5/config_color"
+    },
+    {
+        "input": "/io/in/LCL/5/g",
+        "output": "/headamp/5/gain"
+    },
+    {
+        "input": "/io/in/LCL/5/name",
+        "output": "/headamp/5/config_name"
+    },
+    {
+        "input": "/io/in/LCL/5/vph",
+        "output": "/headamp/5/phantom"
+    },
+    {
+        "input": "/io/in/LCL/6/col",
+        "output": "/headamp/6/config_color"
+    },
+    {
+        "input": "/io/in/LCL/6/g",
+        "output": "/headamp/6/gain"
+    },
+    {
+        "input": "/io/in/LCL/6/name",
+        "output": "/headamp/6/config_name"
+    },
+    {
+        "input": "/io/in/LCL/6/vph",
+        "output": "/headamp/6/phantom"
+    },
+    {
+        "input": "/io/in/LCL/7/col",
+        "output": "/headamp/7/config_color"
+    },
+    {
+        "input": "/io/in/LCL/7/g",
+        "output": "/headamp/7/gain"
+    },
+    {
+        "input": "/io/in/LCL/7/name",
+        "output": "/headamp/7/config_name"
+    },
+    {
+        "input": "/io/in/LCL/7/vph",
+        "output": "/headamp/7/phantom"
+    },
+    {
+        "input": "/io/in/LCL/8/col",
+        "output": "/headamp/8/config_color"
+    },
+    {
+        "input": "/io/in/LCL/8/g",
+        "output": "/headamp/8/gain"
+    },
+    {
+        "input": "/io/in/LCL/8/name",
+        "output": "/headamp/8/config_name"
+    },
+    {
+        "input": "/io/in/LCL/8/vph",
+        "output": "/headamp/8/phantom"
+    },
+    {
+        "input": "/main/1/col",
+        "output": "/main/1/config_color"
+    },
+    {
+        "input": "/main/1/fdr",
+        "output": "/main/1/mix_fader"
+    },
+    {
+        "input": "/main/1/mute",
+        "output": "/main/1/mix_on"
+    },
+    {
+        "input": "/main/1/name",
+        "output": "/main/1/config_name"
+    },
+    {
+        "input": "/main/2/col",
+        "output": "/main/2/config_color"
+    },
+    {
+        "input": "/main/2/fdr",
+        "output": "/main/2/mix_fader"
+    },
+    {
+        "input": "/main/2/mute",
+        "output": "/main/2/mix_on"
+    },
+    {
+        "input": "/main/2/name",
+        "output": "/main/2/config_name"
+    },
+    {
+        "input": "/main/3/col",
+        "output": "/main/3/config_color"
+    },
+    {
+        "input": "/main/3/fdr",
+        "output": "/main/3/mix_fader"
+    },
+    {
+        "input": "/main/3/mute",
+        "output": "/main/3/mix_on"
+    },
+    {
+        "input": "/main/3/name",
+        "output": "/main/3/config_name"
+    },
+    {
+        "input": "/main/4/col",
+        "output": "/main/4/config_color"
+    },
+    {
+        "input": "/main/4/fdr",
+        "output": "/main/4/mix_fader"
+    },
+    {
+        "input": "/main/4/mute",
+        "output": "/main/4/mix_on"
+    },
+    {
+        "input": "/main/4/name",
+        "output": "/main/4/config_name"
+    },
+    {
+        "input": "/mgrp/1/mute",
+        "output": "/mutegroups/1/on"
+    },
+    {
+        "input": "/mgrp/2/mute",
+        "output": "/mutegroups/2/on"
+    },
+    {
+        "input": "/mgrp/3/mute",
+        "output": "/mutegroups/3/on"
+    },
+    {
+        "input": "/mgrp/4/mute",
+        "output": "/mutegroups/4/on"
+    },
+    {
+        "input": "/mgrp/5/mute",
+        "output": "/mutegroups/5/on"
+    },
+    {
+        "input": "/mgrp/6/mute",
+        "output": "/mutegroups/6/on"
+    },
+    {
+        "input": "/mgrp/7/mute",
+        "output": "/mutegroups/7/on"
+    },
+    {
+        "input": "/mgrp/8/mute",
+        "output": "/mutegroups/8/on"
+    },
+    {
+        "input": "/mtx/1/col",
+        "output": "/mtx/1/config_color"
+    },
+    {
+        "input": "/mtx/1/fdr",
+        "output": "/mtx/1/mix_fader"
+    },
+    {
+        "input": "/mtx/1/mute",
+        "output": "/mtx/1/mix_on"
+    },
+    {
+        "input": "/mtx/1/name",
+        "output": "/mtx/1/config_name"
+    },
+    {
+        "input": "/mtx/2/col",
+        "output": "/mtx/2/config_color"
+    },
+    {
+        "input": "/mtx/2/fdr",
+        "output": "/mtx/2/mix_fader"
+    },
+    {
+        "input": "/mtx/2/mute",
+        "output": "/mtx/2/mix_on"
+    },
+    {
+        "input": "/mtx/2/name",
+        "output": "/mtx/2/config_name"
+    },
+    {
+        "input": "/mtx/3/col",
+        "output": "/mtx/3/config_color"
+    },
+    {
+        "input": "/mtx/3/fdr",
+        "output": "/mtx/3/mix_fader"
+    },
+    {
+        "input": "/mtx/3/mute",
+        "output": "/mtx/3/mix_on"
+    },
+    {
+        "input": "/mtx/3/name",
+        "output": "/mtx/3/config_name"
+    },
+    {
+        "input": "/mtx/4/col",
+        "output": "/mtx/4/config_color"
+    },
+    {
+        "input": "/mtx/4/fdr",
+        "output": "/mtx/4/mix_fader"
+    },
+    {
+        "input": "/mtx/4/mute",
+        "output": "/mtx/4/mix_on"
+    },
+    {
+        "input": "/mtx/4/name",
+        "output": "/mtx/4/config_name"
+    },
+    {
+        "input": "/mtx/5/col",
+        "output": "/mtx/5/config_color"
+    },
+    {
+        "input": "/mtx/5/fdr",
+        "output": "/mtx/5/mix_fader"
+    },
+    {
+        "input": "/mtx/5/mute",
+        "output": "/mtx/5/mix_on"
+    },
+    {
+        "input": "/mtx/5/name",
+        "output": "/mtx/5/config_name"
+    },
+    {
+        "input": "/mtx/6/col",
+        "output": "/mtx/6/config_color"
+    },
+    {
+        "input": "/mtx/6/fdr",
+        "output": "/mtx/6/mix_fader"
+    },
+    {
+        "input": "/mtx/6/mute",
+        "output": "/mtx/6/mix_on"
+    },
+    {
+        "input": "/mtx/6/name",
+        "output": "/mtx/6/config_name"
+    },
+    {
+        "input": "/mtx/7/col",
+        "output": "/mtx/7/config_color"
+    },
+    {
+        "input": "/mtx/7/fdr",
+        "output": "/mtx/7/mix_fader"
+    },
+    {
+        "input": "/mtx/7/mute",
+        "output": "/mtx/7/mix_on"
+    },
+    {
+        "input": "/mtx/7/name",
+        "output": "/mtx/7/config_name"
+    },
+    {
+        "input": "/mtx/8/col",
+        "output": "/mtx/8/config_color"
+    },
+    {
+        "input": "/mtx/8/fdr",
+        "output": "/mtx/8/mix_fader"
+    },
+    {
+        "input": "/mtx/8/mute",
+        "output": "/mtx/8/mix_on"
+    },
+    {
+        "input": "/mtx/8/name",
+        "output": "/mtx/8/config_name"
+    },
+    {
+        "input": "/play/$actfile",
+        "output": "/usb/file"
+    },
+    {
+        "input": "/play/$actidx",
+        "output": "/usb/playlist/index"
+    },
+    {
+        "input": "/play/$actlist",
+        "output": "/usb/playlist/path"
+    },
+    {
+        "input": "/play/$actstate",
+        "output": "/usb/state"
+    },
+    {
+        "input": "/play/$songs",
+        "output": "/usb/playlist/songs"
+    },
+    {
+        "input": "/rec/$actfile",
+        "output": "/usb/rec/file"
+    },
+    {
+        "input": "/rec/$action",
+        "output": "/usb/rec/action"
+    },
+    {
+        "input": "/rec/$actstate",
+        "output": "/usb/rec/state"
+    },
+    {
+        "input": "/rec/$time",
+        "output": "/usb/rec/time"
+    },
+    {
+        "input": "/rec/channels",
+        "output": "/usb/rec/channels"
+    },
+    {
+        "input": "/rec/path",
+        "output": "/usb/rec/path"
+    },
+    {
+        "input": "/rec/resolution",
+        "output": "/usb/rec/resolution"
+    }
+]

--- a/tests/wingmapping.json
+++ b/tests/wingmapping.json
@@ -28,6 +28,10 @@
         "output": "/auxin/1/mix_fader"
     },
     {
+        "input": "/aux/1/led",
+        "output": "/auxin/1/config_led"
+    },
+    {
         "input": "/aux/1/mute",
         "output": "/auxin/1/mix_on"
     },
@@ -42,6 +46,10 @@
     {
         "input": "/aux/2/fdr",
         "output": "/auxin/2/mix_fader"
+    },
+    {
+        "input": "/aux/2/led",
+        "output": "/auxin/2/config_led"
     },
     {
         "input": "/aux/2/mute",
@@ -60,6 +68,10 @@
         "output": "/auxin/3/mix_fader"
     },
     {
+        "input": "/aux/3/led",
+        "output": "/auxin/3/config_led"
+    },
+    {
         "input": "/aux/3/mute",
         "output": "/auxin/3/mix_on"
     },
@@ -74,6 +86,10 @@
     {
         "input": "/aux/4/fdr",
         "output": "/auxin/4/mix_fader"
+    },
+    {
+        "input": "/aux/4/led",
+        "output": "/auxin/4/config_led"
     },
     {
         "input": "/aux/4/mute",
@@ -92,6 +108,10 @@
         "output": "/auxin/5/mix_fader"
     },
     {
+        "input": "/aux/5/led",
+        "output": "/auxin/5/config_led"
+    },
+    {
         "input": "/aux/5/mute",
         "output": "/auxin/5/mix_on"
     },
@@ -106,6 +126,10 @@
     {
         "input": "/aux/6/fdr",
         "output": "/auxin/6/mix_fader"
+    },
+    {
+        "input": "/aux/6/led",
+        "output": "/auxin/6/config_led"
     },
     {
         "input": "/aux/6/mute",
@@ -124,6 +148,10 @@
         "output": "/auxin/7/mix_fader"
     },
     {
+        "input": "/aux/7/led",
+        "output": "/auxin/7/config_led"
+    },
+    {
         "input": "/aux/7/mute",
         "output": "/auxin/7/mix_on"
     },
@@ -138,6 +166,10 @@
     {
         "input": "/aux/8/fdr",
         "output": "/auxin/8/mix_fader"
+    },
+    {
+        "input": "/aux/8/led",
+        "output": "/auxin/8/config_led"
     },
     {
         "input": "/aux/8/mute",
@@ -5656,6 +5688,10 @@
         "output": "/ch/1/input_trim"
     },
     {
+        "input": "/ch/1/led",
+        "output": "/ch/1/config_led"
+    },
+    {
         "input": "/ch/1/mute",
         "output": "/ch/1/mix_on"
     },
@@ -5858,6 +5894,10 @@
     {
         "input": "/ch/10/in/set/trim",
         "output": "/ch/10/input_trim"
+    },
+    {
+        "input": "/ch/10/led",
+        "output": "/ch/10/config_led"
     },
     {
         "input": "/ch/10/mute",
@@ -6064,6 +6104,10 @@
         "output": "/ch/11/input_trim"
     },
     {
+        "input": "/ch/11/led",
+        "output": "/ch/11/config_led"
+    },
+    {
         "input": "/ch/11/mute",
         "output": "/ch/11/mix_on"
     },
@@ -6266,6 +6310,10 @@
     {
         "input": "/ch/12/in/set/trim",
         "output": "/ch/12/input_trim"
+    },
+    {
+        "input": "/ch/12/led",
+        "output": "/ch/12/config_led"
     },
     {
         "input": "/ch/12/mute",
@@ -6472,6 +6520,10 @@
         "output": "/ch/13/input_trim"
     },
     {
+        "input": "/ch/13/led",
+        "output": "/ch/13/config_led"
+    },
+    {
         "input": "/ch/13/mute",
         "output": "/ch/13/mix_on"
     },
@@ -6674,6 +6726,10 @@
     {
         "input": "/ch/14/in/set/trim",
         "output": "/ch/14/input_trim"
+    },
+    {
+        "input": "/ch/14/led",
+        "output": "/ch/14/config_led"
     },
     {
         "input": "/ch/14/mute",
@@ -6880,6 +6936,10 @@
         "output": "/ch/15/input_trim"
     },
     {
+        "input": "/ch/15/led",
+        "output": "/ch/15/config_led"
+    },
+    {
         "input": "/ch/15/mute",
         "output": "/ch/15/mix_on"
     },
@@ -7082,6 +7142,10 @@
     {
         "input": "/ch/16/in/set/trim",
         "output": "/ch/16/input_trim"
+    },
+    {
+        "input": "/ch/16/led",
+        "output": "/ch/16/config_led"
     },
     {
         "input": "/ch/16/mute",
@@ -7288,6 +7352,10 @@
         "output": "/ch/17/input_trim"
     },
     {
+        "input": "/ch/17/led",
+        "output": "/ch/17/config_led"
+    },
+    {
         "input": "/ch/17/mute",
         "output": "/ch/17/mix_on"
     },
@@ -7490,6 +7558,10 @@
     {
         "input": "/ch/18/in/set/trim",
         "output": "/ch/18/input_trim"
+    },
+    {
+        "input": "/ch/18/led",
+        "output": "/ch/18/config_led"
     },
     {
         "input": "/ch/18/mute",
@@ -7696,6 +7768,10 @@
         "output": "/ch/19/input_trim"
     },
     {
+        "input": "/ch/19/led",
+        "output": "/ch/19/config_led"
+    },
+    {
         "input": "/ch/19/mute",
         "output": "/ch/19/mix_on"
     },
@@ -7898,6 +7974,10 @@
     {
         "input": "/ch/2/in/set/trim",
         "output": "/ch/2/input_trim"
+    },
+    {
+        "input": "/ch/2/led",
+        "output": "/ch/2/config_led"
     },
     {
         "input": "/ch/2/mute",
@@ -8104,6 +8184,10 @@
         "output": "/ch/20/input_trim"
     },
     {
+        "input": "/ch/20/led",
+        "output": "/ch/20/config_led"
+    },
+    {
         "input": "/ch/20/mute",
         "output": "/ch/20/mix_on"
     },
@@ -8306,6 +8390,10 @@
     {
         "input": "/ch/21/in/set/trim",
         "output": "/ch/21/input_trim"
+    },
+    {
+        "input": "/ch/21/led",
+        "output": "/ch/21/config_led"
     },
     {
         "input": "/ch/21/mute",
@@ -8512,6 +8600,10 @@
         "output": "/ch/22/input_trim"
     },
     {
+        "input": "/ch/22/led",
+        "output": "/ch/22/config_led"
+    },
+    {
         "input": "/ch/22/mute",
         "output": "/ch/22/mix_on"
     },
@@ -8714,6 +8806,10 @@
     {
         "input": "/ch/23/in/set/trim",
         "output": "/ch/23/input_trim"
+    },
+    {
+        "input": "/ch/23/led",
+        "output": "/ch/23/config_led"
     },
     {
         "input": "/ch/23/mute",
@@ -8920,6 +9016,10 @@
         "output": "/ch/24/input_trim"
     },
     {
+        "input": "/ch/24/led",
+        "output": "/ch/24/config_led"
+    },
+    {
         "input": "/ch/24/mute",
         "output": "/ch/24/mix_on"
     },
@@ -9122,6 +9222,10 @@
     {
         "input": "/ch/25/in/set/trim",
         "output": "/ch/25/input_trim"
+    },
+    {
+        "input": "/ch/25/led",
+        "output": "/ch/25/config_led"
     },
     {
         "input": "/ch/25/mute",
@@ -9328,6 +9432,10 @@
         "output": "/ch/26/input_trim"
     },
     {
+        "input": "/ch/26/led",
+        "output": "/ch/26/config_led"
+    },
+    {
         "input": "/ch/26/mute",
         "output": "/ch/26/mix_on"
     },
@@ -9530,6 +9638,10 @@
     {
         "input": "/ch/27/in/set/trim",
         "output": "/ch/27/input_trim"
+    },
+    {
+        "input": "/ch/27/led",
+        "output": "/ch/27/config_led"
     },
     {
         "input": "/ch/27/mute",
@@ -9736,6 +9848,10 @@
         "output": "/ch/28/input_trim"
     },
     {
+        "input": "/ch/28/led",
+        "output": "/ch/28/config_led"
+    },
+    {
         "input": "/ch/28/mute",
         "output": "/ch/28/mix_on"
     },
@@ -9938,6 +10054,10 @@
     {
         "input": "/ch/29/in/set/trim",
         "output": "/ch/29/input_trim"
+    },
+    {
+        "input": "/ch/29/led",
+        "output": "/ch/29/config_led"
     },
     {
         "input": "/ch/29/mute",
@@ -10144,6 +10264,10 @@
         "output": "/ch/3/input_trim"
     },
     {
+        "input": "/ch/3/led",
+        "output": "/ch/3/config_led"
+    },
+    {
         "input": "/ch/3/mute",
         "output": "/ch/3/mix_on"
     },
@@ -10346,6 +10470,10 @@
     {
         "input": "/ch/30/in/set/trim",
         "output": "/ch/30/input_trim"
+    },
+    {
+        "input": "/ch/30/led",
+        "output": "/ch/30/config_led"
     },
     {
         "input": "/ch/30/mute",
@@ -10552,6 +10680,10 @@
         "output": "/ch/31/input_trim"
     },
     {
+        "input": "/ch/31/led",
+        "output": "/ch/31/config_led"
+    },
+    {
         "input": "/ch/31/mute",
         "output": "/ch/31/mix_on"
     },
@@ -10754,6 +10886,10 @@
     {
         "input": "/ch/32/in/set/trim",
         "output": "/ch/32/input_trim"
+    },
+    {
+        "input": "/ch/32/led",
+        "output": "/ch/32/config_led"
     },
     {
         "input": "/ch/32/mute",
@@ -10960,6 +11096,10 @@
         "output": "/ch/33/input_trim"
     },
     {
+        "input": "/ch/33/led",
+        "output": "/ch/33/config_led"
+    },
+    {
         "input": "/ch/33/mute",
         "output": "/ch/33/mix_on"
     },
@@ -11162,6 +11302,10 @@
     {
         "input": "/ch/34/in/set/trim",
         "output": "/ch/34/input_trim"
+    },
+    {
+        "input": "/ch/34/led",
+        "output": "/ch/34/config_led"
     },
     {
         "input": "/ch/34/mute",
@@ -11368,6 +11512,10 @@
         "output": "/ch/35/input_trim"
     },
     {
+        "input": "/ch/35/led",
+        "output": "/ch/35/config_led"
+    },
+    {
         "input": "/ch/35/mute",
         "output": "/ch/35/mix_on"
     },
@@ -11570,6 +11718,10 @@
     {
         "input": "/ch/36/in/set/trim",
         "output": "/ch/36/input_trim"
+    },
+    {
+        "input": "/ch/36/led",
+        "output": "/ch/36/config_led"
     },
     {
         "input": "/ch/36/mute",
@@ -11776,6 +11928,10 @@
         "output": "/ch/37/input_trim"
     },
     {
+        "input": "/ch/37/led",
+        "output": "/ch/37/config_led"
+    },
+    {
         "input": "/ch/37/mute",
         "output": "/ch/37/mix_on"
     },
@@ -11978,6 +12134,10 @@
     {
         "input": "/ch/38/in/set/trim",
         "output": "/ch/38/input_trim"
+    },
+    {
+        "input": "/ch/38/led",
+        "output": "/ch/38/config_led"
     },
     {
         "input": "/ch/38/mute",
@@ -12184,6 +12344,10 @@
         "output": "/ch/39/input_trim"
     },
     {
+        "input": "/ch/39/led",
+        "output": "/ch/39/config_led"
+    },
+    {
         "input": "/ch/39/mute",
         "output": "/ch/39/mix_on"
     },
@@ -12386,6 +12550,10 @@
     {
         "input": "/ch/4/in/set/trim",
         "output": "/ch/4/input_trim"
+    },
+    {
+        "input": "/ch/4/led",
+        "output": "/ch/4/config_led"
     },
     {
         "input": "/ch/4/mute",
@@ -12592,6 +12760,10 @@
         "output": "/ch/40/input_trim"
     },
     {
+        "input": "/ch/40/led",
+        "output": "/ch/40/config_led"
+    },
+    {
         "input": "/ch/40/mute",
         "output": "/ch/40/mix_on"
     },
@@ -12794,6 +12966,10 @@
     {
         "input": "/ch/5/in/set/trim",
         "output": "/ch/5/input_trim"
+    },
+    {
+        "input": "/ch/5/led",
+        "output": "/ch/5/config_led"
     },
     {
         "input": "/ch/5/mute",
@@ -13000,6 +13176,10 @@
         "output": "/ch/6/input_trim"
     },
     {
+        "input": "/ch/6/led",
+        "output": "/ch/6/config_led"
+    },
+    {
         "input": "/ch/6/mute",
         "output": "/ch/6/mix_on"
     },
@@ -13202,6 +13382,10 @@
     {
         "input": "/ch/7/in/set/trim",
         "output": "/ch/7/input_trim"
+    },
+    {
+        "input": "/ch/7/led",
+        "output": "/ch/7/config_led"
     },
     {
         "input": "/ch/7/mute",
@@ -13408,6 +13592,10 @@
         "output": "/ch/8/input_trim"
     },
     {
+        "input": "/ch/8/led",
+        "output": "/ch/8/config_led"
+    },
+    {
         "input": "/ch/8/mute",
         "output": "/ch/8/mix_on"
     },
@@ -13610,6 +13798,10 @@
     {
         "input": "/ch/9/in/set/trim",
         "output": "/ch/9/input_trim"
+    },
+    {
+        "input": "/ch/9/led",
+        "output": "/ch/9/config_led"
     },
     {
         "input": "/ch/9/mute",
@@ -16698,10 +16890,6 @@
     {
         "input": "/rec/channels",
         "output": "/usb/rec/channels"
-    },
-    {
-        "input": "/rec/path",
-        "output": "/usb/rec/path"
     },
     {
         "input": "/rec/resolution",


### PR DESCRIPTION
Everything tested with wing rack fw 3.1. 
Hope that helps. 

## Summary
- Expanded WING OSC mapping and documentation (headamps, channel preamp, USB player/recorder, bus→bus, bus→matrix/main pre, /status handling, scribble light mapping).
- Added WING variants: WINGRACK and WINGCOMPACT.
- Improved WING info/ACK handling.
- Updated WING color indexing (18 colors, 0-based internal indices with 1-based device writes; no OFF observed) and headamp gain normalization.
- Added Wing test.

## New / expanded tags
- `headamps`
- `channelpreamp`
- `usbrec`
- `busbussends`

## New keys / expanded keys
**Channel preamp**
- `/ch/<n>/preamp_gain`
- `/ch/<n>/preamp_phantom`
- `/ch/<n>/input_mode`
- `/ch/<n>/input_srcauto`
- `/ch/<n>/input_altsrc`
- `/ch/<n>/input_invert`
- `/ch/<n>/input_trim`
- `/ch/<n>/input_balance`
- `/ch/<n>/input_delay_mode`
- `/ch/<n>/input_delay`
- `/ch/<n>/input_delay_on`
- `/ch/<n>/input_conn_grp`
- `/ch/<n>/input_conn_in`
- `/ch/<n>/input_alt_conn_grp`
- `/ch/<n>/input_alt_conn_in`

**Scribble light**
- `/ch/<n>/config_led`
- `/auxin/<n>/config_led`

**Headamps (local + AES50)**
- `/headamp/<n>/gain`, `/headamp/<n>/phantom`, `/headamp/<n>/config_name`, `/headamp/<n>/config_color`
- `/headamp/a/<n>/gain`, `/headamp/a/<n>/phantom`, `/headamp/a/<n>/config_name`, `/headamp/a/<n>/config_color`
- `/headamp/b/<n>/gain`, `/headamp/b/<n>/phantom`, `/headamp/b/<n>/config_name`, `/headamp/b/<n>/config_color`
- `/headamp/c/<n>/gain`, `/headamp/c/<n>/phantom`, `/headamp/c/<n>/config_name`, `/headamp/c/<n>/config_color`

**USB player**
- `/usb/playlist/path`
- `/usb/playlist/index`
- `/usb/playlist/songs`

**USB recorder**
- `/usb/rec/state`
- `/usb/rec/file`
- `/usb/rec/action`
- `/usb/rec/resolution`
- `/usb/rec/channels`
- `/usb/rec/time`

**Bus sends**
- `/busbussend/<bus>/<send>/mix_on`
- `/busbussend/<bus>/<send>/mix_fader`
- `/busbussend/<bus>/<send>/pre`
- `/bussend/<bus>/<matrix>/pre`
- `/busmainsend/<bus>/<main>/pre`

**Info**
- `/status`

## Details
- Mapping notes + new WING tags & keys: [mixer_type_wing.py](https://github.com/wrodie/behringer-mixer/blob/feature/wing-headamp-support-clean/behringer_mixer/mixers/mixer_type_wing.py)
- WING info/ACK handling: [mixer_base.py](https://github.com/wrodie/behringer-mixer/blob/feature/wing-headamp-support-clean/behringer_mixer/mixer_base.py)
- WING colors + gain clamp: [utils.py](https://github.com/wrodie/behringer-mixer/blob/feature/wing-headamp-support-clean/behringer_mixer/utils.py)
- WING variants:
  - [mixer_types.py](https://github.com/wrodie/behringer-mixer/blob/feature/wing-headamp-support-clean/behringer_mixer/mixer_types.py)
  - [mixer_type_wing_rack.py](https://github.com/wrodie/behringer-mixer/blob/feature/wing-headamp-support-clean/behringer_mixer/mixers/mixer_type_wing_rack.py)
  - [mixer_type_wing_compact.py](https://github.com/wrodie/behringer-mixer/blob/feature/wing-headamp-support-clean/behringer_mixer/mixers/mixer_type_wing_compact.py)
- Snapshot test:
  - [test_mapping.py](https://github.com/wrodie/behringer-mixer/blob/feature/wing-headamp-support-clean/tests/test_mapping.py)
  - [wingmapping.json](https://github.com/wrodie/behringer-mixer/blob/feature/wing-headamp-support-clean/tests/wingmapping.json)